### PR TITLE
Implement layers

### DIFF
--- a/drilldown/__init__.py
+++ b/drilldown/__init__.py
@@ -1,5 +1,6 @@
 from .holes import DrillHole, DrillHoleGroup, Intervals, Points, Collars, Surveys
 from .plotter import DrillDownPlotter
+
 from .ui.ui import DrillDownTramePlotter, DrillDownPanelPlotter
 from .image.image import ImageViewer
 

--- a/drilldown/holes.py
+++ b/drilldown/holes.py
@@ -6,6 +6,7 @@ from geoh5py.objects import Drillhole
 import numpy as np
 import pandas as pd
 import distinctipy
+from matplotlib.colors import ListedColormap
 
 from .plotter import DrillDownPlotter
 from .drill_log import DrillLog
@@ -13,7 +14,6 @@ from .utils import (
     convert_to_numpy_array,
     convert_array_type,
     encode_categorical_data,
-    make_matplotlib_categorical_color_map,
     make_categorical_cmap,
     make_color_map_fractional,
 )
@@ -202,9 +202,7 @@ class HoleData:
 
             # create matplotlib categorical color map
             codes.sort()
-            self.matplotlib_formatted_color_maps[
-                var_name
-            ] = make_matplotlib_categorical_color_map(
+            self.matplotlib_formatted_color_maps[var_name] = ListedColormap(
                 [self.code_to_color_map[var_name][code] for code in codes]
             )
 

--- a/drilldown/holes.py
+++ b/drilldown/holes.py
@@ -281,9 +281,17 @@ class Points(HoleData):
                         mesh[var] = data
                     else:
                         mesh.point_data[var] = data
+
+                mesh.point_data["depth"] = depths
                 mesh.point_data["hole ID"] = [
                     self.cat_to_code_map["hole ID"][id]
                 ] * depths.shape[0]
+
+                mesh.point_data["x"] = depths_desurveyed[:, 0]
+                mesh.point_data["y"] = depths_desurveyed[:, 1]
+                mesh.point_data["z"] = depths_desurveyed[:, 2]
+
+                self.continuous_vars += ["depth", "x", "y", "z"]
 
                 if meshes is None:
                     meshes = mesh

--- a/drilldown/image/image.py
+++ b/drilldown/image/image.py
@@ -8,20 +8,7 @@ from aiohttp import web
 import large_image
 import uuid
 
-
-def is_jupyter():
-    from IPython import get_ipython
-
-    try:
-        shell = get_ipython().__class__.__name__
-        if shell == "ZMQInteractiveShell":
-            return True  # Jupyter notebook or qtconsole
-        elif shell == "TerminalInteractiveShell":
-            return False  # Terminal running IPython
-        else:
-            return False  # Other type (?)
-    except NameError:
-        return False
+from ..utils import is_jupyter
 
 
 class ImageViewer:

--- a/drilldown/image/image.py
+++ b/drilldown/image/image.py
@@ -33,6 +33,9 @@ class ImageViewer:
 
         self.image_filename = None
 
+        # control auto updating
+        self.auto_update = True
+
     def show(self, image_filename=None, inline=True):
         if image_filename is not None:
             self.update(image_filename)
@@ -88,8 +91,8 @@ class ImageViewer:
 
     def update(self, filename):
         self.image_handler.open_image(filename)
-        self.state.tile_url = self.image_handler.create_request()
-        self.state.flush()  # shouldn't be necessary... but inexplicably is to remove previous image's tiles
+        with self.state:
+            self.state.tile_url = self.image_handler.create_request()
 
 
 # Open raster with large-image

--- a/drilldown/image/image_mixin.py
+++ b/drilldown/image/image_mixin.py
@@ -1,6 +1,6 @@
 class ImageMixin:
-    def _make_single_selection(self, picked, on_filter=False):
-        super(ImageMixin, self)._make_single_selection(picked, on_filter=on_filter)
+    def _update_selection_object(self):
+        super(ImageMixin, self)._update_selection_object()
 
         if (self.im_viewer is not None) and (self.im_viewer.auto_update == True):
             data = self.selected_data

--- a/drilldown/image/image_mixin.py
+++ b/drilldown/image/image_mixin.py
@@ -2,28 +2,27 @@ class ImageMixin:
     def __init__(self):
         pass
 
-    def selected_image(self, var_name=None, **kwargs):
+    def selected_image(self, array_name=None):
         from .image import ImageViewer
 
-        data = self.selected_data()
+        data = self.selected_data
         if data.shape[0] != 1:
             raise ValueError(
                 "More than one interval or point selected. Please select only one."
             )
 
-        if var_name is None:
-            dataset_name = self.selection_actor_name.split(" ")[0]
-            dataset = self.datasets[dataset_name]
-            image_var_names = dataset.image_var_names
-            if len(image_var_names) == 1:
-                var_name = image_var_names[0]
+        if array_name is None:
+            image_array_names = self._image_array_names
+            if len(image_array_names) == 1:
+                array_name = image_array_names[0]
             else:
                 raise ValueError(
-                    "Multiple image variables present. Please specify variable name."
+                    "Multiple image arrays present. Please specify array name."
                 )
 
-        image_filename = data[var_name].values[0]
-        im_viewer = ImageViewer()
-        im_viewer.image_filename = image_filename
+        image_filename = data[array_name].values[0]
+        if image_filename != "nan":
+            im_viewer = ImageViewer()
+            im_viewer.image_filename = image_filename
 
-        return im_viewer
+            return im_viewer

--- a/drilldown/image/image_mixin.py
+++ b/drilldown/image/image_mixin.py
@@ -4,26 +4,28 @@ class ImageMixin:
 
         if (self.im_viewer is not None) and (self.im_viewer.auto_update == True):
             data = self.selected_data
-            image_array_names = self._image_array_names
-            if len(image_array_names) == 1:
-                array_name = image_array_names[0]
+            if self.image_viewer_active_array_name is None:
+                image_array_names = self._image_array_names
+            else:  # use the array name that was last used
+                image_array_names = self.image_viewer_active_array_name
+
+            if isinstance(image_array_names, list):
+                if len(image_array_names) == 1:
+                    array_name = image_array_names[0]
+                else:
+                    raise ValueError(
+                        "Multiple image arrays present. Please specify array name."
+                    )
             else:
-                raise ValueError(
-                    "Multiple image arrays present. Please specify array name."
-                )
+                array_name = image_array_names
 
             image_filename = data[array_name].values[0]
             self.im_viewer.update(image_filename)
 
-    def selected_image(self, array_name=None, auto_update=True):
+    def selected_images(self, array_name=None, auto_update=True):
         from .image import ImageViewer
 
-        data = self.selected_data
-        if data.shape[0] != 1:
-            raise ValueError(
-                "More than one interval or point selected. Please select only one."
-            )
-
+        self.image_viewer_active_array_name = array_name
         if array_name is None:
             image_array_names = self._image_array_names
             if len(image_array_names) == 1:
@@ -33,12 +35,17 @@ class ImageMixin:
                     "Multiple image arrays present. Please specify array name."
                 )
 
-        image_filename = data[array_name].values[0]
-        if image_filename != "nan":
+        if array_name not in self.array_names:  # check if array name is valid
+            raise ValueError(f"{array_name} is not a valid array name.")
+
+        data = self.selected_data
+
+        image_filenames = data[array_name].to_list()
+        if len(image_filenames) != 0:
             im_viewer = ImageViewer()
             im_viewer.auto_update = auto_update
             self.im_viewer = im_viewer
 
-            im_viewer.image_filename = image_filename
+            im_viewer.image_filenames = image_filenames
 
             return im_viewer

--- a/drilldown/image/image_mixin.py
+++ b/drilldown/image/image_mixin.py
@@ -1,8 +1,21 @@
 class ImageMixin:
-    def __init__(self):
-        pass
+    def _make_single_selection(self, picked, on_filter=False):
+        super(ImageMixin, self)._make_single_selection(picked, on_filter=on_filter)
 
-    def selected_image(self, array_name=None):
+        if (self.im_viewer is not None) and (self.im_viewer.auto_update == True):
+            data = self.selected_data
+            image_array_names = self._image_array_names
+            if len(image_array_names) == 1:
+                array_name = image_array_names[0]
+            else:
+                raise ValueError(
+                    "Multiple image arrays present. Please specify array name."
+                )
+
+            image_filename = data[array_name].values[0]
+            self.im_viewer.update(image_filename)
+
+    def selected_image(self, array_name=None, auto_update=True):
         from .image import ImageViewer
 
         data = self.selected_data
@@ -23,6 +36,9 @@ class ImageMixin:
         image_filename = data[array_name].values[0]
         if image_filename != "nan":
             im_viewer = ImageViewer()
+            im_viewer.auto_update = auto_update
+            self.im_viewer = im_viewer
+
             im_viewer.image_filename = image_filename
 
             return im_viewer

--- a/drilldown/layer/inter_layer_mixin.py
+++ b/drilldown/layer/inter_layer_mixin.py
@@ -1,6 +1,7 @@
 import pandas as pd
 
 
+# intervals by intervals
 def filter_intervals_by_intervals(from_to, ranges, overlap="partial", tolerance=0.001):
     partial_fun = lambda row: any(
         (
@@ -74,75 +75,177 @@ def select_hole_intervals_by_intervals(
     return selected_ids
 
 
+# intervals by points
+def filter_intervals_by_points(from_to, depths, tolerance=0.001):
+    overlap_fun = lambda row: any(
+        ((depth - row["from"] > tolerance) and (row["to"] - depth > tolerance))
+        for depth in depths
+    )
+
+    overlap_filter = from_to.apply(overlap_fun, axis=1).tolist()
+
+    return overlap_filter
+
+
+def select_intervals_by_points(from_to, depths, tolerance=0.001):
+    overlap_filter = filter_intervals_by_points(from_to, depths, tolerance)
+    overlap_selection = from_to[overlap_filter].index.tolist()
+
+    return overlap_selection
+
+
+def filter_hole_intervals_by_points(hole_id, from_to, depths, tolerance=0.001):
+    overlap_filter = pd.Series(index=hole_id.index, data=False)
+    hole_ids = [hole for hole in list(set(hole_id)) if hole in depths.keys()]
+    for hole in hole_ids:
+        hole_filter = hole_id == hole
+        hole_from_to = from_to[hole_filter]
+        hole_depths = depths[hole]
+        overlap_filter[hole_filter] = filter_intervals_by_points(
+            hole_from_to, hole_depths, tolerance
+        )
+
+    return overlap_filter.tolist()
+
+
+def select_hole_intervals_by_points(hole_id, from_to, depths, tolerance=0.001):
+    selected_ids = []
+    hole_ids = [hole for hole in list(set(hole_id)) if hole in depths.keys()]
+    for hole in hole_ids:
+        hole_filter = hole_id == hole
+        hole_from_to = from_to[hole_filter]
+        hole_depths = depths[hole]
+        selected_ids += select_intervals_by_points(hole_from_to, hole_depths, tolerance)
+
+    return selected_ids
+
+
+# Interval Mixin
 class IntervalInterLayerMixin:
     def filter_by_selection(self, layer, overlap="partial", tolerance=0.001):
+        from .layer import IntervalDataLayer, PointDataLayer
+
         from_to = self.data[["from", "to"]]
         hole_id = self.data["hole ID"]
 
         selected_data = layer.selected_data
-        ranges = {}
-        for hole in layer.selected_hole_ids:
-            ranges[hole] = selected_data[selected_data["hole ID"] == hole][
-                ["from", "to"]
-            ].values
 
-        overlap_filter = filter_hole_intervals_by_intervals(
-            hole_id, from_to, ranges, overlap, tolerance
-        )
+        if isinstance(layer, IntervalDataLayer):
+            ranges = {}
+            for hole in layer.selected_hole_ids:
+                ranges[hole] = selected_data[selected_data["hole ID"] == hole][
+                    ["from", "to"]
+                ].values
+
+            overlap_filter = filter_hole_intervals_by_intervals(
+                hole_id, from_to, ranges, overlap, tolerance
+            )
+
+        elif isinstance(layer, PointDataLayer):
+            depths = {}
+            for hole in layer.selected_hole_ids:
+                depths[hole] = selected_data[selected_data["hole ID"] == hole]["depth"]
+
+            overlap_filter = filter_hole_intervals_by_points(
+                hole_id, from_to, depths, tolerance
+            )
+
         self.boolean_filter = overlap_filter
 
         return self
 
     def select_by_selection(self, layer, overlap="partial", tolerance=0.001):
+        from .layer import IntervalDataLayer, PointDataLayer
+
         from_to = self.data[["from", "to"]]
         hole_id = self.data["hole ID"]
 
         selected_data = layer.selected_data
-        ranges = {}
-        for hole in layer.selected_hole_ids:
-            ranges[hole] = selected_data[selected_data["hole ID"] == hole][
-                ["from", "to"]
-            ].values
 
-        selected_ids = select_hole_intervals_by_intervals(
-            hole_id, from_to, ranges, overlap, tolerance
-        )
+        if isinstance(layer, IntervalDataLayer):
+            ranges = {}
+            for hole in layer.selected_hole_ids:
+                ranges[hole] = selected_data[selected_data["hole ID"] == hole][
+                    ["from", "to"]
+                ].values
+
+            selected_ids = select_hole_intervals_by_intervals(
+                hole_id, from_to, ranges, overlap, tolerance
+            )
+
+        elif isinstance(layer, PointDataLayer):
+            depths = {}
+            for hole in layer.selected_hole_ids:
+                depths[hole] = selected_data[selected_data["hole ID"] == hole]["depth"]
+
+            selected_ids = select_hole_intervals_by_points(
+                hole_id, from_to, depths, tolerance
+            )
+
         self.selected_ids = selected_ids
 
         return self
 
     def filter_by_filter(self, layer, overlap="partial", tolerance=0.001):
+        from .layer import IntervalDataLayer, PointDataLayer
+
         from_to = self.data[["from", "to"]]
         hole_id = self.data["hole ID"]
 
         filtered_data = layer.filtered_data
-        ranges = {}
-        for hole in layer.filtered_hole_ids:
-            ranges[hole] = filtered_data[filtered_data["hole ID"] == hole][
-                ["from", "to"]
-            ].values
 
-        overlap_filter = filter_hole_intervals_by_intervals(
-            hole_id, from_to, ranges, overlap, tolerance
-        )
+        if isinstance(layer, IntervalDataLayer):
+            ranges = {}
+            for hole in layer.filtered_hole_ids:
+                ranges[hole] = filtered_data[filtered_data["hole ID"] == hole][
+                    ["from", "to"]
+                ].values
+
+            overlap_filter = filter_hole_intervals_by_intervals(
+                hole_id, from_to, ranges, overlap, tolerance
+            )
+
+        elif isinstance(layer, PointDataLayer):
+            depths = {}
+            for hole in layer.filtered_hole_ids:
+                depths[hole] = filtered_data[filtered_data["hole ID"] == hole]["depth"]
+
+            overlap_filter = filter_hole_intervals_by_points(
+                hole_id, from_to, depths, tolerance
+            )
+
         self.boolean_filter = overlap_filter
 
         return self
 
     def select_by_filter(self, layer, overlap="partial", tolerance=0.001):
+        from .layer import IntervalDataLayer, PointDataLayer
+
         from_to = self.data[["from", "to"]]
         hole_id = self.data["hole ID"]
 
         filtered_data = layer.filtered_data
-        ranges = {}
-        for hole in layer.filtered_hole_ids:
-            ranges[hole] = filtered_data[filtered_data["hole ID"] == hole][
-                ["from", "to"]
-            ].values
 
-        selected_ids = select_hole_intervals_by_intervals(
-            hole_id, from_to, ranges, overlap, tolerance
-        )
+        if isinstance(layer, IntervalDataLayer):
+            ranges = {}
+            for hole in layer.filtered_hole_ids:
+                ranges[hole] = filtered_data[filtered_data["hole ID"] == hole][
+                    ["from", "to"]
+                ].values
+
+            selected_ids = select_hole_intervals_by_intervals(
+                hole_id, from_to, ranges, overlap, tolerance
+            )
+
+        elif isinstance(layer, PointDataLayer):
+            depths = {}
+            for hole in layer.filtered_hole_ids:
+                depths[hole] = filtered_data[filtered_data["hole ID"] == hole]["depth"]
+
+            selected_ids = select_hole_intervals_by_points(
+                hole_id, from_to, depths, tolerance
+            )
+
         self.selected_ids = selected_ids
 
         return self

--- a/drilldown/layer/inter_layer_mixin.py
+++ b/drilldown/layer/inter_layer_mixin.py
@@ -1,0 +1,125 @@
+import pandas as pd
+
+
+def filter_by_depth_ranges(from_to, ranges, overlap="partial"):
+    partial_fun = lambda row: any(
+        (not ((row["from"] >= to_depth) or (row["to"] <= from_depth)))
+        for from_depth, to_depth in ranges
+    )
+    complete_fun = lambda row: any(
+        (
+            (not ((row["from"] >= to_depth) or (row["to"] <= from_depth)))
+            and (row["from"] >= from_depth)
+            and (row["to"] <= to_depth)
+        )
+        for from_depth, to_depth in ranges
+    )
+
+    if overlap == "complete":
+        overlap_fun = complete_fun
+    elif overlap == "partial":
+        overlap_fun = partial_fun
+
+    overlap_filter = from_to.apply(overlap_fun, axis=1).tolist()
+
+    return overlap_filter
+
+
+def select_by_depth_ranges(from_to, ranges, overlap="partial"):
+    overlap_filter = filter_by_depth_ranges(from_to, ranges, overlap)
+    overlap_selection = from_to[overlap_filter].index.tolist()
+
+    return overlap_selection
+
+
+def filter_holes_by_depth_ranges(hole_id, from_to, ranges, overlap="partial"):
+    overlap_filter = pd.Series(index=hole_id.index, data=False)
+    hole_ids = [hole for hole in list(set(hole_id)) if hole in ranges.keys()]
+    for hole in hole_ids:
+        hole_filter = hole_id == hole
+        hole_from_to = from_to[hole_filter]
+        hole_ranges = ranges[hole]
+        overlap_filter[hole_filter] = filter_by_depth_ranges(
+            hole_from_to, hole_ranges, overlap
+        )
+        print(overlap_filter[hole_filter])
+
+    return overlap_filter.tolist()
+
+
+def select_holes_by_depth_ranges(hole_id, from_to, ranges, overlap="partial"):
+    selected_ids = []
+    hole_ids = [hole for hole in list(set(hole_id)) if hole in ranges.keys()]
+    for hole in hole_ids:
+        hole_filter = hole_id == hole
+        hole_from_to = from_to[hole_filter]
+        hole_ranges = ranges[hole]
+        selected_ids += select_by_depth_ranges(hole_from_to, hole_ranges, overlap)
+
+    return selected_ids
+
+
+class IntervalByMixin:
+    def filter_by_selection(self, layer, overlap="partial"):
+        from_to = self.data[["from", "to"]]
+        hole_id = self.data["hole ID"]
+
+        selected_data = layer.selected_data
+        ranges = {}
+        for hole in layer.selected_hole_ids:
+            ranges[hole] = selected_data[selected_data["hole ID"] == hole][
+                ["from", "to"]
+            ].values
+
+        overlap_filter = filter_holes_by_depth_ranges(hole_id, from_to, ranges, overlap)
+        self.boolean_filter = overlap_filter
+
+        return self
+
+    def select_by_selection(self, layer, overlap="partial"):
+        from_to = self.data[["from", "to"]]
+        hole_id = self.data["hole ID"]
+
+        selected_data = layer.selected_data
+        ranges = {}
+        for hole in layer.selected_hole_ids:
+            ranges[hole] = selected_data[selected_data["hole ID"] == hole][
+                ["from", "to"]
+            ].values
+
+        selected_ids = select_holes_by_depth_ranges(hole_id, from_to, ranges, overlap)
+        self.selected_ids = selected_ids
+
+        return self
+
+    def filter_by_filter(self, layer, overlap="partial"):
+        from_to = self.data[["from", "to"]]
+        hole_id = self.data["hole ID"]
+
+        filtered_data = layer.filtered_data
+        ranges = {}
+        for hole in layer.filtered_hole_ids:
+            ranges[hole] = filtered_data[filtered_data["hole ID"] == hole][
+                ["from", "to"]
+            ].values
+
+        overlap_filter = filter_holes_by_depth_ranges(hole_id, from_to, ranges, overlap)
+        self.boolean_filter = overlap_filter
+
+        return self
+
+    def select_by_filter(self, layer, overlap="partial"):
+        from_to = self.data[["from", "to"]]
+        hole_id = self.data["hole ID"]
+
+        filtered_data = layer.filtered_data
+        ranges = {}
+        for hole in layer.filtered_hole_ids:
+            ranges[hole] = filtered_data[filtered_data["hole ID"] == hole][
+                ["from", "to"]
+            ].values
+
+        selected_ids = select_holes_by_depth_ranges(hole_id, from_to, ranges, overlap)
+        self.selected_ids = selected_ids
+
+        return self

--- a/drilldown/layer/inter_layer_mixin.py
+++ b/drilldown/layer/inter_layer_mixin.py
@@ -1,6 +1,99 @@
 import pandas as pd
 
 
+# points by points
+def filter_points_by_points(depths_1, depths_2, tolerance=0.001):
+    overlap_fun = lambda row: any(
+        ((depth - row["depth"] > tolerance) and (row["depth"] - depth > tolerance))
+        for depth in depths_2
+    )
+
+    overlap_filter = depths_1.apply(overlap_fun, axis=1).tolist()
+
+    return overlap_filter
+
+
+def select_points_by_points(depths_1, depths_2, tolerance=0.001):
+    overlap_filter = filter_points_by_points(depths_1, depths_2, tolerance)
+    overlap_selection = depths_1[overlap_filter].index.tolist()
+
+    return overlap_selection
+
+
+def filter_hole_points_by_points(hole_id, depths_1, depths_2, tolerance=0.001):
+    overlap_filter = pd.Series(index=hole_id.index, data=False)
+    hole_ids = [hole for hole in list(set(hole_id)) if hole in depths_2.keys()]
+    for hole in hole_ids:
+        hole_filter = hole_id == hole
+        hole_depths_1 = depths_1[hole_filter]
+        hole_depths_2 = depths_2[hole]
+        overlap_filter[hole_filter] = filter_points_by_points(
+            hole_depths_1, hole_depths_2, tolerance
+        )
+
+    return overlap_filter.tolist()
+
+
+def select_hole_points_by_points(hole_id, depths_1, depths_2, tolerance=0.001):
+    selected_ids = []
+    hole_ids = [hole for hole in list(set(hole_id)) if hole in depths_2.keys()]
+    for hole in hole_ids:
+        hole_filter = hole_id == hole
+        hole_depths_1 = depths_1[hole_filter]
+        hole_depths_2 = depths_2[hole]
+        selected_ids += select_points_by_points(hole_depths_1, hole_depths_2, tolerance)
+
+    return selected_ids
+
+
+# points by intervals
+def filter_points_by_intervals(depths, ranges, tolerance=0.001):
+    overlap_fun = lambda row: any(
+        (
+            (row["depth"] - from_depth > tolerance)
+            and (to_depth - row["depth"] > tolerance)
+        )
+        for from_depth, to_depth in ranges
+    )
+
+    overlap_filter = depths.apply(overlap_fun, axis=1).tolist()
+
+    return overlap_filter
+
+
+def select_points_by_intervals(depths, ranges, tolerance=0.001):
+    overlap_filter = filter_points_by_intervals(depths, ranges, tolerance)
+    overlap_selection = depths[overlap_filter].index.tolist()
+
+    return overlap_selection
+
+
+def filter_hole_points_by_intervals(hole_id, depths, ranges, tolerance=0.001):
+    overlap_filter = pd.Series(index=hole_id.index, data=False)
+    hole_ids = [hole for hole in list(set(hole_id)) if hole in ranges.keys()]
+    for hole in hole_ids:
+        hole_filter = hole_id == hole
+        hole_depths = depths[hole_filter]
+        hole_ranges = ranges[hole]
+        overlap_filter[hole_filter] = filter_points_by_intervals(
+            hole_depths, hole_ranges, tolerance
+        )
+
+    return overlap_filter.tolist()
+
+
+def select_hole_points_by_intervals(hole_id, depths, ranges, tolerance=0.001):
+    selected_ids = []
+    hole_ids = [hole for hole in list(set(hole_id)) if hole in ranges.keys()]
+    for hole in hole_ids:
+        hole_filter = hole_id == hole
+        hole_depths = depths[hole_filter]
+        hole_ranges = ranges[hole]
+        selected_ids += select_points_by_intervals(hole_depths, hole_ranges, tolerance)
+
+    return selected_ids
+
+
 # intervals by intervals
 def filter_intervals_by_intervals(from_to, ranges, overlap="partial", tolerance=0.001):
     partial_fun = lambda row: any(
@@ -118,6 +211,145 @@ def select_hole_intervals_by_points(hole_id, from_to, depths, tolerance=0.001):
         selected_ids += select_intervals_by_points(hole_from_to, hole_depths, tolerance)
 
     return selected_ids
+
+
+# Point Mixin
+class PointInterLayerMixin:
+    def filter_by_selection(self, layer, tolerance=0.001):
+        from .layer import IntervalDataLayer, PointDataLayer
+
+        depths = self.data[["depth"]]
+        hole_id = self.data["hole ID"]
+
+        selected_data = layer.selected_data
+
+        if isinstance(layer, IntervalDataLayer):
+            ranges = {}
+            for hole in layer.selected_hole_ids:
+                ranges[hole] = selected_data[selected_data["hole ID"] == hole][
+                    ["from", "to"]
+                ].values
+
+            overlap_filter = filter_hole_points_by_intervals(
+                hole_id, depths, ranges, tolerance
+            )
+
+        elif isinstance(layer, PointDataLayer):
+            depths_2 = {}
+            for hole in layer.selected_hole_ids:
+                depths_2[hole] = selected_data[selected_data["hole ID"] == hole][
+                    "depth"
+                ]
+
+            overlap_filter = filter_hole_points_by_points(
+                hole_id, depths, depths_2, tolerance
+            )
+
+        self.boolean_filter = overlap_filter
+
+        return self
+
+    def select_by_selection(self, layer, tolerance=0.001):
+        from .layer import IntervalDataLayer, PointDataLayer
+
+        depths = self.data[["depth"]]
+        hole_id = self.data["hole ID"]
+
+        selected_data = layer.selected_data
+
+        if isinstance(layer, IntervalDataLayer):
+            ranges = {}
+            for hole in layer.selected_hole_ids:
+                ranges[hole] = selected_data[selected_data["hole ID"] == hole][
+                    ["from", "to"]
+                ].values
+
+            selected_ids = select_hole_points_by_intervals(
+                hole_id, depths, ranges, tolerance
+            )
+
+        elif isinstance(layer, PointDataLayer):
+            depths_2 = {}
+            for hole in layer.selected_hole_ids:
+                depths_2[hole] = selected_data[selected_data["hole ID"] == hole][
+                    "depth"
+                ]
+
+            selected_ids = select_hole_points_by_points(
+                hole_id, depths, depths_2, tolerance
+            )
+
+        self.selected_ids = selected_ids
+
+        return self
+
+    def filter_by_filter(self, layer, tolerance=0.001):
+        from .layer import IntervalDataLayer, PointDataLayer
+
+        depths = self.data[["depth"]]
+        hole_id = self.data["hole ID"]
+
+        filtered_data = layer.filtered_data
+
+        if isinstance(layer, IntervalDataLayer):
+            ranges = {}
+            for hole in layer.filtered_hole_ids:
+                ranges[hole] = filtered_data[filtered_data["hole ID"] == hole][
+                    ["from", "to"]
+                ].values
+
+            overlap_filter = filter_hole_points_by_intervals(
+                hole_id, depths, ranges, tolerance
+            )
+
+        elif isinstance(layer, PointDataLayer):
+            depths_2 = {}
+            for hole in layer.filtered_hole_ids:
+                depths_2[hole] = filtered_data[filtered_data["hole ID"] == hole][
+                    "depth"
+                ]
+
+            overlap_filter = filter_hole_points_by_points(
+                hole_id, depths, depths_2, tolerance
+            )
+
+        self.boolean_filter = overlap_filter
+
+        return self
+
+    def select_by_filter(self, layer, tolerance=0.001):
+        from .layer import IntervalDataLayer, PointDataLayer
+
+        depths = self.data[["depth"]]
+        hole_id = self.data["hole ID"]
+
+        filtered_data = layer.filtered_data
+
+        if isinstance(layer, IntervalDataLayer):
+            ranges = {}
+            for hole in layer.filtered_hole_ids:
+                ranges[hole] = filtered_data[filtered_data["hole ID"] == hole][
+                    ["from", "to"]
+                ].values
+
+            selected_ids = select_hole_points_by_intervals(
+                hole_id, depths, ranges, tolerance
+            )
+
+        elif isinstance(layer, PointDataLayer):
+            depths_2 = {}
+            for hole in layer.filtered_hole_ids:
+                depths_2[hole] = filtered_data[filtered_data["hole ID"] == hole][
+                    "depth"
+                ]
+
+            selected_ids = select_hole_points_by_points(
+                hole_id, depths, depths_2, tolerance
+            )
+
+        self.selected_ids = selected_ids
+
+        return self
 
 
 # Interval Mixin

--- a/drilldown/layer/inter_layer_mixin.py
+++ b/drilldown/layer/inter_layer_mixin.py
@@ -247,8 +247,6 @@ class PointInterLayerMixin:
 
         self.boolean_filter = overlap_filter
 
-        return self
-
     def select_by_selection(self, layer, tolerance=0.001):
         from .layer import IntervalDataLayer, PointDataLayer
 
@@ -280,8 +278,6 @@ class PointInterLayerMixin:
             )
 
         self.selected_ids = selected_ids
-
-        return self
 
     def filter_by_filter(self, layer, tolerance=0.001):
         from .layer import IntervalDataLayer, PointDataLayer
@@ -315,8 +311,6 @@ class PointInterLayerMixin:
 
         self.boolean_filter = overlap_filter
 
-        return self
-
     def select_by_filter(self, layer, tolerance=0.001):
         from .layer import IntervalDataLayer, PointDataLayer
 
@@ -349,7 +343,61 @@ class PointInterLayerMixin:
 
         self.selected_ids = selected_ids
 
-        return self
+    def filter_by(self, layer, tolerance=0.001):
+        from .layer import IntervalDataLayer, PointDataLayer
+
+        depths = self.data[["depth"]]
+        hole_id = self.data["hole ID"]
+
+        data = layer.data
+
+        if isinstance(layer, IntervalDataLayer):
+            ranges = {}
+            for hole in layer.filtered_hole_ids:
+                ranges[hole] = data[data["hole ID"] == hole][["from", "to"]].values
+
+            overlap_filter = filter_hole_points_by_intervals(
+                hole_id, depths, ranges, tolerance
+            )
+
+        elif isinstance(layer, PointDataLayer):
+            depths_2 = {}
+            for hole in layer.filtered_hole_ids:
+                depths_2[hole] = data[data["hole ID"] == hole]["depth"]
+
+            overlap_filter = filter_hole_points_by_points(
+                hole_id, depths, depths_2, tolerance
+            )
+
+        self.boolean_filter = overlap_filter
+
+    def select_by(self, layer, tolerance=0.001):
+        from .layer import IntervalDataLayer, PointDataLayer
+
+        depths = self.data[["depth"]]
+        hole_id = self.data["hole ID"]
+
+        data = layer.data
+
+        if isinstance(layer, IntervalDataLayer):
+            ranges = {}
+            for hole in layer.hole_ids:
+                ranges[hole] = data[data["hole ID"] == hole][["from", "to"]].values
+
+            selected_ids = select_hole_points_by_intervals(
+                hole_id, depths, ranges, tolerance
+            )
+
+        elif isinstance(layer, PointDataLayer):
+            depths_2 = {}
+            for hole in layer.hole_ids:
+                depths_2[hole] = data[data["hole ID"] == hole]["depth"]
+
+            selected_ids = select_hole_points_by_points(
+                hole_id, depths, depths_2, tolerance
+            )
+
+        self.selected_ids = selected_ids
 
 
 # Interval Mixin
@@ -384,8 +432,6 @@ class IntervalInterLayerMixin:
 
         self.boolean_filter = overlap_filter
 
-        return self
-
     def select_by_selection(self, layer, overlap="partial", tolerance=0.001):
         from .layer import IntervalDataLayer, PointDataLayer
 
@@ -415,8 +461,6 @@ class IntervalInterLayerMixin:
             )
 
         self.selected_ids = selected_ids
-
-        return self
 
     def filter_by_filter(self, layer, overlap="partial", tolerance=0.001):
         from .layer import IntervalDataLayer, PointDataLayer
@@ -448,8 +492,6 @@ class IntervalInterLayerMixin:
 
         self.boolean_filter = overlap_filter
 
-        return self
-
     def select_by_filter(self, layer, overlap="partial", tolerance=0.001):
         from .layer import IntervalDataLayer, PointDataLayer
 
@@ -480,4 +522,58 @@ class IntervalInterLayerMixin:
 
         self.selected_ids = selected_ids
 
-        return self
+    def filter_by(self, layer, overlap="partial", tolerance=0.001):
+        from .layer import IntervalDataLayer, PointDataLayer
+
+        from_to = self.data[["from", "to"]]
+        hole_id = self.data["hole ID"]
+
+        data = layer.data
+
+        if isinstance(layer, IntervalDataLayer):
+            ranges = {}
+            for hole in layer.hole_ids:
+                ranges[hole] = data[data["hole ID"] == hole][["from", "to"]].values
+
+            overlap_filter = filter_hole_intervals_by_intervals(
+                hole_id, from_to, ranges, overlap, tolerance
+            )
+
+        elif isinstance(layer, PointDataLayer):
+            depths = {}
+            for hole in layer.hole_ids:
+                depths[hole] = data[data["hole ID"] == hole]["depth"]
+
+            overlap_filter = filter_hole_intervals_by_points(
+                hole_id, from_to, depths, tolerance
+            )
+
+        self.boolean_filter = overlap_filter
+
+    def select_by(self, layer, overlap="partial", tolerance=0.001):
+        from .layer import IntervalDataLayer, PointDataLayer
+
+        from_to = self.data[["from", "to"]]
+        hole_id = self.data["hole ID"]
+
+        data = layer.data
+
+        if isinstance(layer, IntervalDataLayer):
+            ranges = {}
+            for hole in layer.hole_ids:
+                ranges[hole] = data[data["hole ID"] == hole][["from", "to"]].values
+
+            selected_ids = select_hole_intervals_by_intervals(
+                hole_id, from_to, ranges, overlap, tolerance
+            )
+
+        elif isinstance(layer, PointDataLayer):
+            depths = {}
+            for hole in layer.hole_ids:
+                depths[hole] = data[data["hole ID"] == hole]["depth"]
+
+            selected_ids = select_hole_intervals_by_points(
+                hole_id, from_to, depths, tolerance
+            )
+
+        self.selected_ids = selected_ids

--- a/drilldown/layer/layer.py
+++ b/drilldown/layer/layer.py
@@ -20,7 +20,7 @@ from ..utils import (
 )
 from ..image.image_mixin import ImageMixin
 from ..plot.plotting_mixin import Plotting2dMixin
-from ..layer.inter_layer_mixin import IntervalInterLayerMixin
+from ..layer.inter_layer_mixin import IntervalInterLayerMixin, PointInterLayerMixin
 from ..drill_log import DrillLog
 
 
@@ -1213,7 +1213,7 @@ class _DataLayer(ImageMixin, _BaseLayer, Plotting2dMixin):
         return data
 
 
-class PointDataLayer(_DataLayer, _PointLayer):
+class PointDataLayer(_DataLayer, _PointLayer, PointInterLayerMixin):
     def __init__(self, name, mesh, actor, plotter, *args, **kwargs):
         super().__init__(name, mesh, actor, plotter, *args, **kwargs)
 

--- a/drilldown/layer/layer.py
+++ b/drilldown/layer/layer.py
@@ -725,7 +725,7 @@ class _DataLayer(_BaseLayer):
         mesh,
         actor,
         plotter,
-        active_var=None,
+        active_array_name=None,
         cmap=None,
         clim=None,
         *args,
@@ -733,15 +733,15 @@ class _DataLayer(_BaseLayer):
     ):
         super().__init__(name, mesh, actor, plotter, *args, **kwargs)
 
-        self._active_var = mesh.active_scalars_name
-        print(self._active_var)
+        self._active_array_name = mesh.active_scalars_name
+        print(self._active_array_name)
         print(actor.mapper.lookup_table.cmap.name)
         print(actor.mapper.lookup_table.scalar_range)
         print(actor.mapper.lookup_table.cmap.name)
 
         if hasattr(
             actor.mapper.lookup_table.cmap, "name"
-        ):  # only set if active_var is continuous
+        ):  # only set if active_array_name is continuous
             self._cmap = actor.mapper.lookup_table.cmap
             self._clim = actor.mapper.lookup_table.scalar_range
         else:
@@ -770,11 +770,11 @@ class _DataLayer(_BaseLayer):
         self.mesh.keys()
 
     @property
-    def active_var(self):
-        return self._active_var
+    def active_array_name(self):
+        return self._active_array_name
 
-    @active_var.setter
-    def active_var(self, value):
+    @active_array_name.setter
+    def active_array_name(self, value):
         if value not in self.array_names:
             raise ValueError(f"{value} is not an array name.")
 
@@ -798,7 +798,7 @@ class _DataLayer(_BaseLayer):
 
         self.plotter.render()
 
-        self._active_var = value
+        self._active_array_name = value
 
     @property
     def cmap(self):
@@ -806,7 +806,7 @@ class _DataLayer(_BaseLayer):
 
     @cmap.setter
     def cmap(self, value):
-        if self.active_var in self.continuous_array_names:
+        if self.active_array_name in self.continuous_array_names:
             lookup_table = pv.LookupTable()
             lookup_table.cmap = value
             self.actor.mapper.lookup_table = lookup_table
@@ -823,7 +823,7 @@ class _DataLayer(_BaseLayer):
 
     @clim.setter
     def clim(self, value):
-        if self.active_var in self.continuous_array_names:
+        if self.active_array_name in self.continuous_array_names:
             self.actor.mapper.lookup_table.scalar_range = value
             self.filter_actor.mapper.SetUseLookupTableScalarRange(True)
             if self._filter_actor is not None:

--- a/drilldown/layer/layer.py
+++ b/drilldown/layer/layer.py
@@ -866,6 +866,9 @@ class _DataLayer(_BaseLayer, ImageMixin, Plotting2dMixin):
     def data_within_interval(self, hole_id, interval):
         pass
 
+    def _make_selection_by_dbl_click_pick(self):
+        self.selected_hole_ids = self.selected_hole_ids
+
     @property
     def selected_ids(self):
         raise NotImplementedError("This method must be implemented in a subclass.")
@@ -898,6 +901,9 @@ class _DataLayer(_BaseLayer, ImageMixin, Plotting2dMixin):
             raise ValueError("hole_ids must be a list, numpy array, or pandas Series.")
 
         data = self.all_data
+        if self.filter_actor is not None:
+            data = data[self.boolean_filter]
+
         matches = data["hole ID"].isin(hole_ids)
         self.selected_ids = data.loc[matches].index.tolist()
 

--- a/drilldown/layer/layer.py
+++ b/drilldown/layer/layer.py
@@ -12,6 +12,7 @@ import pandas as pd
 import matplotlib.pyplot as plt
 
 from ..utils import convert_to_numpy_array
+from ..image.image_mixin import ImageMixin
 
 
 class _BaseLayer:
@@ -726,7 +727,7 @@ class _IntervalLayer(_BaseLayer):
         return np.arange(self.n_intervals)
 
 
-class _DataLayer(_BaseLayer):
+class _DataLayer(_BaseLayer, ImageMixin):
     def __init__(
         self,
         name,

--- a/drilldown/layer/layer.py
+++ b/drilldown/layer/layer.py
@@ -767,6 +767,7 @@ class _DataLayer(ImageMixin, _BaseLayer, Plotting2dMixin):
 
         self._cmaps = plt.colormaps()
 
+        self.array_names = []
         self._continuous_array_names = []
         self._categorical_array_names = []
 
@@ -783,6 +784,7 @@ class _DataLayer(ImageMixin, _BaseLayer, Plotting2dMixin):
 
         # active image viewer
         self.im_viewer = None
+        self.im_viewer_active_array_name = None
 
     @property
     def active_array_name(self):

--- a/drilldown/layer/layer.py
+++ b/drilldown/layer/layer.py
@@ -13,6 +13,7 @@ import matplotlib.pyplot as plt
 
 from ..utils import convert_to_numpy_array
 from ..image.image_mixin import ImageMixin
+from ..plot.plotting_mixin import Plotting2dMixin
 
 
 class _BaseLayer:
@@ -727,7 +728,7 @@ class _IntervalLayer(_BaseLayer):
         return np.arange(self.n_intervals)
 
 
-class _DataLayer(_BaseLayer, ImageMixin):
+class _DataLayer(_BaseLayer, ImageMixin, Plotting2dMixin):
     def __init__(
         self,
         name,

--- a/drilldown/layer/layer.py
+++ b/drilldown/layer/layer.py
@@ -767,7 +767,6 @@ class _DataLayer(ImageMixin, _BaseLayer, Plotting2dMixin):
 
         self._cmaps = plt.colormaps()
 
-        self.array_names = []
         self._continuous_array_names = []
         self._categorical_array_names = []
 

--- a/drilldown/layer/layer.py
+++ b/drilldown/layer/layer.py
@@ -604,12 +604,11 @@ class _IntervalLayer(_BaseLayer):
         if (selection_mesh.n_points != 0) and (selection_mesh.n_cells != 0):
             selection_actor = self.plotter.add_mesh(
                 selection_mesh,
-                self.name + " selection",
+                name=self.name + " selection",
                 color=self.selection_color,
                 opacity=self.opacity * self.rel_selection_opacity,
                 reset_camera=False,
                 pickable=False,
-                as_selection=True,
             )
             self._selection_actor = selection_actor
 
@@ -734,10 +733,6 @@ class _DataLayer(_BaseLayer):
         super().__init__(name, mesh, actor, plotter, *args, **kwargs)
 
         self._active_array_name = mesh.active_scalars_name
-        print(self._active_array_name)
-        print(actor.mapper.lookup_table.cmap.name)
-        print(actor.mapper.lookup_table.scalar_range)
-        print(actor.mapper.lookup_table.cmap.name)
 
         if hasattr(
             actor.mapper.lookup_table.cmap, "name"

--- a/drilldown/layer/layer.py
+++ b/drilldown/layer/layer.py
@@ -959,6 +959,11 @@ class PointDataLayer(_PointLayer, _DataLayer):
 
     def __setitem__(self, key, value):
         self.mesh[key] = value
+        if self.filter_actor is not None:
+            self.filter_actor.mapper.dataset[key] = value[self.boolean_filter]
+        else:
+            self.mesh[key] = value
+
         self.active_array_name = key
         self.array_names.append(key)
         if np.issubdtype(value.dtype, np.number):
@@ -1029,6 +1034,10 @@ class IntervalDataLayer(_IntervalLayer, _DataLayer):
         cells_per_interval = self.n_sides
         value = np.repeat(value, cells_per_interval)
         self.mesh[key] = value
+        if self.filter_actor is not None:
+            boolean_filter = np.repeat(self.boolean_filter, cells_per_interval)
+            self.filter_actor.mapper.dataset[key] = value[boolean_filter]
+
         self.active_array_name = key
         self.array_names.append(key)
         if np.issubdtype(value.dtype, np.number):

--- a/drilldown/layer/layer.py
+++ b/drilldown/layer/layer.py
@@ -1,34 +1,60 @@
-from typing import Any
+from vtk import (
+    vtkCellPicker,
+    vtkPointPicker,
+    vtkCellLocator,
+    vtkPointLocator,
+    vtkHardwareSelector,
+    vtkDataObject,
+)
+import numpy as np
+
+from ..utils import convert_to_numpy_array
 
 
-class BaseLayer:
+class _BaseLayer:
     def __init__(
-        self, name, mesh, actor, plotter, visible=True, opacity=1, pickable=True
+        self,
+        name,
+        mesh,
+        actor,
+        plotter,
+        visibility=True,
+        opacity=1,
+        selection_color="magenta",
+        rel_selection_opacity=1,
+        rel_filter_opacity=0.1,
     ):
         self.name = name
         self.mesh = mesh
         self.actor = actor
-        self._visible = visible
+        self._visibility = visibility
         self._opacity = opacity
-        self.pickable = pickable
+        # self._opacity_while_not_visible = opacity
         self.plotter = plotter
 
+        self._selection_actor = None
+        self._filter_actor = None
+
+        self._selection_color = selection_color
+        self._rel_selection_opacity = rel_selection_opacity
+        self._rel_filter_opacity = rel_filter_opacity
+
     @property
-    def visible(self):
-        return self._visible
+    def visibility(self):
+        return self._visibility
 
-    @visible.setter
-    def visible(self, value):
-        if value == True:
-            self.actor.prop.opacity = 1
-        elif value == False:
-            self.actor.prop.opacity = 0
-        else:
-            raise ValueError("visible must be True or False")
+    @visibility.setter
+    def visibility(self, value):
+        self.actor.visibility = value
+        if self._selection_actor is not None:
+            self._selection_actor.visibility = value
 
-        self._visible = value
+        if self._filter_actor is not None:
+            self._filter_actor.visibility = value
 
         self.plotter.render()
+
+        self._visibility = value
 
     @property
     def opacity(self):
@@ -40,27 +66,451 @@ class BaseLayer:
             raise ValueError("opacity must be between 0 and 1")
 
         self.actor.prop.opacity = value
+        if self._selection_actor is not None:
+            self._selection_actor.prop.opacity = value * self._rel_selection_opacity
 
-        self._opacity = value
+        if self._filter_actor is not None:
+            self._filter_actor.prop.opacity = value * self._rel_filter_opacity
 
         self.plotter.render()
 
+        self._opacity = value
 
-class DataLayer(BaseLayer):
+    @property
+    def selection_color(self):
+        return self._selection_color
+
+    @selection_color.setter
+    def selection_color(self, value):
+        if self._selection_actor is not None:
+            self._selection_actor.prop.color = value
+            self.plotter.render()
+
+        self._selection_color = value
+
+    @property
+    def rel_selection_opacity(self):
+        return self._rel_selection_opacity
+
+    @rel_selection_opacity.setter
+    def rel_selection_opacity(self, value):
+        if self._selection_actor is not None:
+            self._selection_actor.prop.opacity = self._opacity * value
+            self.plotter.render()
+
+        self._rel_selection_opacity = value
+
+    @property
+    def rel_filter_opacity(self):
+        return self._rel_filter_opacity
+
+    @rel_filter_opacity.setter
+    def rel_filter_opacity(self, value):
+        if self._filter_actor is not None:
+            self._filter_actor.property.opacity = self._opacity * value
+            self.plotter.render()
+
+        self._rel_filter_opacity = value
+
+
+class _PointLayer(_BaseLayer):
     def __init__(
         self,
         name,
         mesh,
         actor,
         plotter,
-        visible=True,
+        visibility=True,
+        opacity=1,
+        pickable=True,
+        accelerated_picking=False,
+        point_size=15,
+        rel_selected_point_size=1.1,
+        rel_filtered_point_size=1.1,
+    ):
+        super().__init__(name, mesh, actor, plotter, visibility, opacity)
+
+        self.pickable = pickable
+        self.accelerated_picking = accelerated_picking
+
+        self.picker = None
+        self.filter_picker = None
+
+        self._picked_point = None
+        self._selected_points = []
+        self._filtered_points = []
+
+        if self.pickable:
+            self._make_pickable()
+
+        self.point_size = point_size
+        self.rel_selected_point_size = rel_selected_point_size
+        self.rel_filtered_point_size = rel_filtered_point_size
+
+        self.n_points = mesh.n_points
+
+    def _make_pickable(self):
+        self.picker = vtkPointPicker()
+        self.picker.SetTolerance(0.005)
+
+        self.filter_picker = vtkPointPicker()
+        self.filter_picker.SetTolerance(0.005)
+
+        if self.accelerated_picking == True:
+            for picker in [self.picker, self.filter_picker]:
+                # add locator for acceleration
+                locator = vtkPointLocator()
+                locator.SetDataSet(self.mesh)
+                locator.BuildLocator()
+                picker.AddLocator(locator)
+
+                # use hardware selection for acceleration
+                hw_selector = vtkHardwareSelector()
+                hw_selector.SetFieldAssociation(vtkDataObject.FIELD_ASSOCIATION_POINTS)
+                hw_selector.SetRenderer(self.plotter.renderer)
+
+    def _make_selection_by_pick(self, pos, actor):
+        if actor == self.actor:
+            picker = self.picker
+            on_filter = False
+
+        elif actor == self.filter_actor:
+            picker = self.filter_picker
+            on_filter = True
+
+        picker.Pick(pos[0], pos[1], 0, self.plotter.renderer)
+
+        picked_point = picker.GetPointId()
+        if picked_point is not None:
+            if picked_point == -1:
+                return
+            else:
+                shift_pressed = self.plotter.iren.interactor.GetShiftKey()
+                ctrl_pressed = self.plotter.iren.interactor.GetControlKey()
+
+                if shift_pressed:
+                    self._make_continuous_multi_selection(
+                        picked_point, on_filter=on_filter
+                    )
+                elif ctrl_pressed:
+                    self._make_discontinuous_multi_selection(
+                        picked_point, on_filter=on_filter
+                    )
+
+                else:
+                    self._make_single_selection(picked_point, on_filter=on_filter)
+
+                if on_filter:
+                    picked_point = self._filtered_points[picked_point]
+
+                self._picked_point = picked_point
+
+    def _make_single_selection(self, picked_point, on_filter=False):
+        if on_filter:
+            picked_point = self._filtered_points[picked_point]
+
+        self._selected_points = [picked_point]
+
+    def _make_discontinuous_multi_selection(self, picked_point, on_filter=False):
+        pass
+
+    def _make_continuous_multi_selection(self, picked_point, on_filter=False):
+        pass  # not trivial as cell IDs are not inherently sequential along hole
+
+    def _update_selection_object(self):
+        selection_mesh = self.mesh.extract_points(self._selected_points)
+        if (selection_mesh.n_points != 0) and (selection_mesh.n_cells != 0):
+            selection_actor = self.plotter.add_mesh(
+                selection_mesh,
+                self.name + " selection",
+                color=self.selection_color,
+                opacity=self.opacity * self.rel_selection_opacity,
+                point_size=self.point_size * self.rel_selected_point_size,
+                render_points_as_spheres=True,
+                reset_camera=False,
+                pickable=False,
+            )
+
+            self._selection_actor = selection_actor
+            if selection_actor is not None:
+                selection_actor.mapper.SetRelativeCoincidentTopologyPolygonOffsetParameters(
+                    0, -6
+                )
+                self.plotter.render()
+
+            return selection_actor
+
+    def _reset_selection(self):
+        self._picked_point = None
+        self._selected_points = []
+
+        self.plotter.remove_actor(self._selection_actor)
+        self._selection_actor = None
+
+
+class _IntervalLayer(_BaseLayer):
+    def __init__(
+        self,
+        name,
+        mesh,
+        actor,
+        plotter,
+        visibility=True,
+        opacity=1,
+        pickable=True,
+        accelerated_picking=False,
+        n_sides=20,
+    ):
+        super().__init__(name, mesh, actor, plotter, visibility, opacity)
+
+        self.pickable = pickable
+        self.accelerated_picking = accelerated_picking
+
+        self.picker = None
+        self.filter_picker = None
+
+        self._picked_cell = None
+        self._selected_cells = []
+        self._selected_intervals = []
+        self._filtered_cells = []
+        self._filtered_intervals = []
+
+        if self.pickable:
+            self._make_pickable()
+
+        self.n_sides = n_sides
+        self.n_intervals = mesh.n_cells / n_sides
+
+    def _make_pickable(self):
+        self.picker = vtkCellPicker()
+        self.picker.SetTolerance(0.0005)
+
+        self.filter_picker = vtkCellPicker()
+        self.filter_picker.SetTolerance(0.0005)
+
+        if self.accelerated_picking == True:
+            for picker in [self.picker, self.filter_picker]:
+                # add locator for acceleration
+                locator = vtkCellLocator()
+                locator.SetDataSet(self.mesh)
+                locator.BuildLocator()
+                picker.AddLocator(locator)
+
+                # use hardware selection for acceleration
+                hw_selector = vtkHardwareSelector()
+                hw_selector.SetFieldAssociation(vtkDataObject.FIELD_ASSOCIATION_CELLS)
+                hw_selector.SetRenderer(self.plotter.renderer)
+
+    def _make_selection_by_pick(self, pos, actor):
+        if actor == self.actor:
+            picker = self.picker
+            on_filter = False
+
+        elif actor == self.filter_actor:
+            picker = self.filter_picker
+            on_filter = True
+
+        picker.Pick(pos[0], pos[1], 0, self.plotter.renderer)
+
+        picked_cell = picker.GetCellId()
+        if picked_cell is not None:
+            if picked_cell == -1:
+                return
+            else:
+                shift_pressed = self.plotter.iren.interactor.GetShiftKey()
+                ctrl_pressed = self.plotter.iren.interactor.GetControlKey()
+
+                if shift_pressed:
+                    self._make_continuous_multi_selection(
+                        picked_cell, on_filter=on_filter
+                    )
+                elif ctrl_pressed:
+                    self._make_discontinuous_multi_selection(
+                        picked_cell, on_filter=on_filter
+                    )
+
+                else:
+                    self._make_single_selection(picked_cell, on_filter=on_filter)
+
+                if on_filter:
+                    picked_cell = self._filtered_cells[picked_cell]
+
+                self._picked_cell = picked_cell
+
+    def _make_single_selection(self, picked_cell, on_filter=False):
+        cells_per_interval = self.n_sides
+
+        selected_interval = int(np.floor(picked_cell / cells_per_interval))
+
+        selected_cells = np.arange(
+            selected_interval * cells_per_interval,
+            (selected_interval + 1) * cells_per_interval,
+        ).tolist()
+
+        if on_filter:
+            selected_interval = self._filtered_intervals[selected_interval]
+            selected_cells = list(self._filtered_cells[selected_cells])
+
+        self._selected_intervals = [selected_interval]
+        self._selected_cells = selected_cells
+
+    def _make_discontinuous_multi_selection(self, picked_cell, on_filter=False):
+        cells_per_interval = self.n_sides
+
+        selected_interval = int(np.floor(picked_cell / cells_per_interval))
+        selected_cells = np.arange(
+            selected_interval * cells_per_interval,
+            (selected_interval + 1) * cells_per_interval,
+        ).tolist()
+
+        if on_filter:
+            selected_interval = self._filtered_intervals[selected_interval]
+            selected_cells = list(self._filtered_cells[selected_cells])
+
+        self._selected_intervals += [selected_interval]
+        self._selected_cells += selected_cells
+
+    def _make_continuous_multi_selection(self, picked_cell, on_filter=False):
+        cells_per_interval = self.n_sides
+
+        if on_filter:
+            prev_picked_cell = np.where(self._filtered_cells == self._picked_cell)[0][0]
+            prev_selected_intervals = np.where(
+                np.isin(self._filtered_intervals, self._selected_intervals[:-1])
+            )[0].tolist()
+            prev_selected_intervals += np.where(
+                np.isin(self._filtered_intervals, self._selected_intervals[-1])
+            )[
+                0
+            ].tolist()  #  needed as np.isin or np.where seems to sort the output and the resulting first interval should be last
+
+        else:
+            prev_picked_cell = self._picked_cell
+            prev_selected_intervals = self._selected_intervals
+
+        if prev_picked_cell is not None:
+            if prev_picked_cell < picked_cell:  # normal direction (down the hole)
+                selected_intervals = np.arange(
+                    prev_selected_intervals[-1] + 1,
+                    int(np.floor(picked_cell / cells_per_interval)) + 1,
+                ).tolist()
+                selected_cells = np.arange(
+                    (selected_intervals[0]) * cells_per_interval,
+                    (selected_intervals[-1] + 1) * cells_per_interval,
+                ).tolist()
+
+                if on_filter:
+                    selected_intervals = list(
+                        self._filtered_intervals[selected_intervals]
+                    )
+                    selected_cells = list(self._filtered_cells[selected_cells])
+
+                self._selected_intervals += selected_intervals
+                self._selected_cells += selected_cells
+
+            else:  # reverse direction (up the hole)
+                selected_intervals = np.arange(
+                    int(np.floor(picked_cell / cells_per_interval)),
+                    prev_selected_intervals[-1],
+                ).tolist()
+                selected_cells = np.arange(
+                    (selected_intervals[0] * cells_per_interval),
+                    (selected_intervals[-1] + 1) * cells_per_interval,
+                ).tolist()
+
+                if on_filter:
+                    selected_intervals = list(
+                        self._filtered_intervals[selected_intervals]
+                    )
+                    selected_cells = list(self._filtered_cells[selected_cells])
+
+                self._selected_intervals = selected_intervals + self._selected_intervals
+                self._selected_cells = selected_cells + self._selected_cells
+
+    def _update_selection_object(self):
+        selection_mesh = self.mesh.extract_cells(self._selected_cells)
+        if (selection_mesh.n_points != 0) and (selection_mesh.n_cells != 0):
+            selection_actor = self.plotter.add_mesh(
+                selection_mesh,
+                self.name + " selection",
+                color=self.selection_color,
+                opacity=self.opacity * self.rel_selection_opacity,
+                reset_camera=False,
+                pickable=False,
+            )
+            self._selection_actor = selection_actor
+
+            if selection_actor is not None:
+                selection_actor.mapper.SetRelativeCoincidentTopologyPolygonOffsetParameters(
+                    0, -6
+                )
+                self.plotter.render()
+
+            return selection_actor
+
+    def _reset_selection(self):
+        self._picked_cell = None
+        self._selected_cells = []
+        self._selected_intervals = []
+
+        self.plotter.remove_actor(self._selection_actor)
+        self._selection_actor = None
+
+    @property
+    def picked_cell(self):
+        return self._picked_cell
+
+    @property
+    def selected_cells(self):
+        return self._selected_cells
+
+    @property
+    def selected_intervals(self):
+        return self._selected_intervals
+
+    @selected_intervals.setter
+    def selected_intervals(self, intervals):
+        try:
+            intervals = convert_to_numpy_array(intervals)
+        except:
+            raise ValueError(
+                "Intervals must be a sequence, pandas object, or numpy array."
+            )
+
+        if (intervals > self.n_intervals).any() or (intervals < 0).any():
+            raise ValueError(
+                f"Intervals must be between 0 and the number of intervals in the dataset, {self.n_intervals - 1}."
+            )
+
+        interval_cells = []
+        cells_per_interval = self.n_sides
+        for interval in intervals:
+            interval_cells += np.arange(
+                interval * cells_per_interval,
+                (interval + 1) * cells_per_interval,
+            ).tolist()
+
+        self._selected_intervals = intervals
+        self._selected_cells = interval_cells
+
+        self._update_selection_object()
+
+
+class _DataLayer(_BaseLayer):
+    def __init__(
+        self,
+        name,
+        mesh,
+        actor,
+        plotter,
+        visibility=True,
         opacity=1,
         pickable=True,
         active_var=None,
         cmap=None,
         clim=None,
     ):
-        super().__init__(name, mesh, actor, plotter, visible, opacity, pickable)
+        super().__init__(name, mesh, actor, plotter, visibility, opacity, pickable)
 
         self._active_var = active_var
         self._cmap = cmap
@@ -68,9 +518,6 @@ class DataLayer(BaseLayer):
 
         self._continuous_array_names = []
         self._categorical_array_names = []
-
-        self._selection_actor = None
-        self._filter_actor = None
 
     def __getitem__(self, key):
         return self.mesh[key]
@@ -100,3 +547,59 @@ class DataLayer(BaseLayer):
 
     def data_within_interval(self, hole_id, interval):
         pass
+
+
+class PointDataLayer(_DataLayer, _PointLayer):
+    def __init__(
+        self,
+        name,
+        mesh,
+        actor,
+        plotter,
+        visibility=True,
+        opacity=1,
+        pickable=True,
+        active_var=None,
+        cmap=None,
+        clim=None,
+    ):
+        super().__init__(
+            name,
+            mesh,
+            actor,
+            plotter,
+            visibility,
+            opacity,
+            pickable,
+            active_var,
+            cmap,
+            clim,
+        )
+
+
+class IntervalDataLayer(_DataLayer, _IntervalLayer):
+    def __init__(
+        self,
+        name,
+        mesh,
+        actor,
+        plotter,
+        visibility=True,
+        opacity=1,
+        pickable=True,
+        active_var=None,
+        cmap=None,
+        clim=None,
+    ):
+        super().__init__(
+            name,
+            mesh,
+            actor,
+            plotter,
+            visibility,
+            opacity,
+            pickable,
+            active_var,
+            cmap,
+            clim,
+        )

--- a/drilldown/layer/layer.py
+++ b/drilldown/layer/layer.py
@@ -234,7 +234,7 @@ class _PointLayer(_BaseLayer):
         if on_filter:
             picked_point = self.filtered_points[picked_point]
 
-        self._selected_points = [picked_point]
+        self.selected_points = [picked_point]
 
     def _make_discontinuous_multi_selection(self, picked_point, on_filter=False):
         pass
@@ -266,7 +266,7 @@ class _PointLayer(_BaseLayer):
 
     def _reset_selection(self):
         self._picked_point = None
-        self._selected_points = []
+        self.selected_points = []
 
         self.plotter.remove_actor(self._selection_actor)
         self._selection_actor = None
@@ -299,7 +299,7 @@ class _PointLayer(_BaseLayer):
 
     @property
     def selected_ids(self):
-        return self._selected_points
+        return self.selected_points
 
     @selected_ids.setter
     def selected_ids(self, ids):
@@ -488,7 +488,7 @@ class _IntervalLayer(_BaseLayer):
             selected_interval = self.filtered_intervals[selected_interval]
             selected_cells = list(self._filtered_cells[selected_cells])
 
-        self._selected_intervals = [selected_interval]
+        self.selected_intervals = [selected_interval]
         self._selected_cells = selected_cells
 
     def _make_discontinuous_multi_selection(self, picked_cell, on_filter=False):
@@ -504,7 +504,7 @@ class _IntervalLayer(_BaseLayer):
             selected_interval = self.filtered_intervals[selected_interval]
             selected_cells = list(self._filtered_cells[selected_cells])
 
-        self._selected_intervals += [selected_interval]
+        self.selected_intervals += [selected_interval]
         self._selected_cells += selected_cells
 
     def _make_continuous_multi_selection(self, picked_cell, on_filter=False):
@@ -542,7 +542,7 @@ class _IntervalLayer(_BaseLayer):
                     )
                     selected_cells = list(self._filtered_cells[selected_cells])
 
-                self._selected_intervals += selected_intervals
+                self.selected_intervals += selected_intervals
                 self._selected_cells += selected_cells
 
             else:  # reverse direction (up the hole)
@@ -561,7 +561,7 @@ class _IntervalLayer(_BaseLayer):
                     )
                     selected_cells = list(self._filtered_cells[selected_cells])
 
-                self._selected_intervals = selected_intervals + self.selected_intervals
+                self.selected_intervals = selected_intervals + self.selected_intervals
                 self._selected_cells = selected_cells + self._selected_cells
 
     @property
@@ -606,7 +606,7 @@ class _IntervalLayer(_BaseLayer):
 
     @property
     def selected_ids(self):
-        return self._selected_intervals
+        return self.selected_intervals
 
     @selected_ids.setter
     def selected_ids(self, ids):
@@ -634,7 +634,7 @@ class _IntervalLayer(_BaseLayer):
     def _reset_selection(self):
         self._picked_cell = None
         self._selected_cells = []
-        self._selected_intervals = []
+        self.selected_intervals = []
 
         self.plotter.remove_actor(self._selection_actor)
         self._selection_actor = None

--- a/drilldown/layer/layer.py
+++ b/drilldown/layer/layer.py
@@ -73,8 +73,10 @@ class _BaseLayer:
         self.plotter.render()
 
         self._visibility = value
-        with self.state:
-            self.state.visibility = value
+
+        if self.name == self.state.ctrl_mesh_name:
+            with self.state:
+                self.state.visibility = value
 
     @property
     def opacity(self):
@@ -97,8 +99,10 @@ class _BaseLayer:
         self.plotter.render()
 
         self._opacity = value
-        with self.state:
-            self.state.opacity = value
+
+        if self.name == self.state.ctrl_mesh_name:
+            with self.state:
+                self.state.opacity = value
 
     @property
     def selection_actor(self):
@@ -752,39 +756,49 @@ class _DataLayer(ImageMixin, _BaseLayer, Plotting2dMixin):
     ):
         super().__init__(name, mesh, actor, plotter, *args, **kwargs)
         self._active_array_name = mesh.active_scalars_name
-        with self.state:
-            self.state.active_array_name = self._active_array_name
+
+        if self.name == self.state.ctrl_mesh_name:
+            with self.state:
+                self.state.active_array_name = self._active_array_name
 
         if hasattr(
             actor.mapper.lookup_table.cmap, "name"
         ):  # only set if active_array_name is continuous
             self._cmap = actor.mapper.lookup_table.cmap.name
-            with self.state:
-                self.state.cmap = self._cmap
+
+            if self.name == self.state.ctrl_mesh_name:
+                with self.state:
+                    self.state.cmap = self._cmap
 
             self._clim_range = self._calculate_clim_range(self._active_array_name)
             clim_step = (self._clim_range[1] - self._clim_range[0]) / 1000
             self._clim_step = round_to_sig_figs(clim_step, 2)
             self._clim = actor.mapper.lookup_table.scalar_range
-            with self.state:
-                self.state.clim = self._clim
-                self.state.clim_min = self._clim_range[0]
-                self.state.clim_max = self._clim_range[1]
-                self.state.clim_step = self._clim_step
+
+            if self.name == self.state.ctrl_mesh_name:
+                with self.state:
+                    self.state.clim = self._clim
+                    self.state.clim_min = self._clim_range[0]
+                    self.state.clim_max = self._clim_range[1]
+                    self.state.clim_step = self._clim_step
 
         else:
             self._cmap = None
-            with self.state:
-                self.state.cmap = self._cmap
+
+            if self.name == self.state.ctrl_mesh_name:
+                with self.state:
+                    self.state.cmap = self._cmap
 
             self._clim_range = (0, 0)
             self._clim_step = 0
             self._clim = (0, 0)
-            with self.state:
-                self.state.clim = self._clim
-                self.state.clim_min = self._clim_range[0]
-                self.state.clim_max = self._clim_range[1]
-                self.state.clim_step = self._clim_step
+
+            if self.name == self.state.ctrl_mesh_name:
+                with self.state:
+                    self.state.clim = self._clim
+                    self.state.clim_min = self._clim_range[0]
+                    self.state.clim_max = self._clim_range[1]
+                    self.state.clim_step = self._clim_step
 
         self._cmaps = plt.colormaps()
 
@@ -848,8 +862,9 @@ class _DataLayer(ImageMixin, _BaseLayer, Plotting2dMixin):
 
         self.plotter.render()
 
-        with self.state:
-            self.state.active_array_name = value
+        if self.name == self.state.ctrl_mesh_name:
+            with self.state:
+                self.state.active_array_name = value
 
     @property
     def cmap(self):
@@ -867,8 +882,10 @@ class _DataLayer(ImageMixin, _BaseLayer, Plotting2dMixin):
         self.plotter.render()
 
         self._cmap = value
-        with self.state:
-            self.state.cmap = value
+
+        if self.name == self.state.ctrl_mesh_name:
+            with self.state:
+                self.state.cmap = value
 
     @property
     def clim(self):
@@ -901,11 +918,13 @@ class _DataLayer(ImageMixin, _BaseLayer, Plotting2dMixin):
         self.plotter.render()
 
         self._clim = value
-        with self.state:
-            self.state.clim = (
-                np.ceil(value[0] / self._clim_step) * self._clim_step,
-                np.floor(value[1] / self._clim_step) * self._clim_step,
-            )
+
+        if self.name == self.state.ctrl_mesh_name:
+            with self.state:
+                self.state.clim = (
+                    np.ceil(value[0] / self._clim_step) * self._clim_step,
+                    np.floor(value[1] / self._clim_step) * self._clim_step,
+                )
 
     def reset_clim(self):
         if not self.active_array_name in self.continuous_array_names:
@@ -938,13 +957,21 @@ class _DataLayer(ImageMixin, _BaseLayer, Plotting2dMixin):
         # update clim_step
         clim_step = (value[1] - value[0]) / 1000
         self._clim_step = round_to_sig_figs(clim_step, 2)
-        with self.state:
-            self.state.clim_step = self._clim_step
+
+        if self.name == self.state.ctrl_mesh_name:
+            with self.state:
+                self.state.clim_step = self._clim_step
 
         self._clim_range = value
-        with self.state:
-            self.state.clim_min = np.floor(value[0] / self._clim_step) * self._clim_step
-            self.state.clim_max = np.ceil(value[1] / self._clim_step) * self._clim_step
+
+        if self.name == self.state.ctrl_mesh_name:
+            with self.state:
+                self.state.clim_min = (
+                    np.floor(value[0] / self._clim_step) * self._clim_step
+                )
+                self.state.clim_max = (
+                    np.ceil(value[1] / self._clim_step) * self._clim_step
+                )
 
     def _calculate_clim_range(self, array_name):
         array = self.mesh[array_name]
@@ -971,18 +998,21 @@ class _DataLayer(ImageMixin, _BaseLayer, Plotting2dMixin):
         clim_step = (clim_range[1] - clim_range[0]) / 1000
         self._clim_step = round_to_sig_figs(clim_step, 2)
 
-        with self.state:
-            self.state.clim_step = self._clim_step
+        if self.name == self.state.ctrl_mesh_name:
+            with self.state:
+                self.state.clim_step = self._clim_step
 
         # reset clim_range
         self._clim_range = clim_range
-        with self.state:
-            self.state.clim_min = (
-                np.floor(clim_range[0] / self._clim_step) * self._clim_step
-            )
-            self.state.clim_max = (
-                np.ceil(clim_range[1] / self._clim_step) * self._clim_step
-            )
+
+        if self.name == self.state.ctrl_mesh_name:
+            with self.state:
+                self.state.clim_min = (
+                    np.floor(clim_range[0] / self._clim_step) * self._clim_step
+                )
+                self.state.clim_max = (
+                    np.ceil(clim_range[1] / self._clim_step) * self._clim_step
+                )
 
         # reset clim
         self.actor.mapper.lookup_table.scalar_range = clim_range
@@ -994,11 +1024,13 @@ class _DataLayer(ImageMixin, _BaseLayer, Plotting2dMixin):
         self.plotter.render()
 
         self._clim = clim_range
-        with self.state:
-            self.state.clim = (
-                np.ceil(clim_range[0] / self._clim_step) * self._clim_step,
-                np.floor(clim_range[1] / self._clim_step) * self._clim_step,
-            )
+
+        if self.name == self.state.ctrl_mesh_name:
+            with self.state:
+                self.state.clim = (
+                    np.ceil(clim_range[0] / self._clim_step) * self._clim_step,
+                    np.floor(clim_range[1] / self._clim_step) * self._clim_step,
+                )
 
     @property
     def clim_step(self):
@@ -1117,8 +1149,10 @@ class PointDataLayer(_DataLayer, _PointLayer):
 
         if key not in self.array_names:
             self.array_names.append(key)
-            with self.state:
-                self.state.array_names = self.array_names
+
+            if self.name == self.state.ctrl_mesh_name:
+                with self.state:
+                    self.state.array_names = self.array_names
 
     def _process_data_output(self, ids, array_names=[]):
         exclude = ["vtkOriginalPointIds", "vtkOriginalCellIds"]  # added by pyvista
@@ -1209,8 +1243,10 @@ class IntervalDataLayer(_DataLayer, _IntervalLayer):
 
         if key not in self.array_names:
             self.array_names.append(key)
-            with self.state:
-                self.state.array_names = self.array_names
+
+            if self.name == self.state.ctrl_mesh_name:
+                with self.state:
+                    self.state.array_names = self.array_names
 
     def _make_selection_by_dbl_click_pick(self, pos, actor):
         if actor == self.actor:

--- a/drilldown/layer/layer.py
+++ b/drilldown/layer/layer.py
@@ -1,0 +1,102 @@
+from typing import Any
+
+
+class BaseLayer:
+    def __init__(
+        self, name, mesh, actor, plotter, visible=True, opacity=1, pickable=True
+    ):
+        self.name = name
+        self.mesh = mesh
+        self.actor = actor
+        self._visible = visible
+        self._opacity = opacity
+        self.pickable = pickable
+        self.plotter = plotter
+
+    @property
+    def visible(self):
+        return self._visible
+
+    @visible.setter
+    def visible(self, value):
+        if value == True:
+            self.actor.prop.opacity = 1
+        elif value == False:
+            self.actor.prop.opacity = 0
+        else:
+            raise ValueError("visible must be True or False")
+
+        self._visible = value
+
+        self.plotter.render()
+
+    @property
+    def opacity(self):
+        return self._opacity
+
+    @opacity.setter
+    def opacity(self, value):
+        if value < 0 or value > 1:
+            raise ValueError("opacity must be between 0 and 1")
+
+        self.actor.prop.opacity = value
+
+        self._opacity = value
+
+        self.plotter.render()
+
+
+class DataLayer(BaseLayer):
+    def __init__(
+        self,
+        name,
+        mesh,
+        actor,
+        plotter,
+        visible=True,
+        opacity=1,
+        pickable=True,
+        active_var=None,
+        cmap=None,
+        clim=None,
+    ):
+        super().__init__(name, mesh, actor, plotter, visible, opacity, pickable)
+
+        self._active_var = active_var
+        self._cmap = cmap
+        self._clim = clim
+
+        self._continuous_array_names = []
+        self._categorical_array_names = []
+
+        self._selection_actor = None
+        self._filter_actor = None
+
+    def __getitem__(self, key):
+        return self.mesh[key]
+
+    def __setitem__(self, key, value):
+        self.mesh[key] = value
+        self.mesh.keys()
+
+    def array_names(self):
+        return self.mesh.array_names
+
+    @property
+    def continuous_array_names(self):
+        return self._continuous_array_names
+
+    @continuous_array_names.setter
+    def continuous_array_names(self, value):
+        self._continuous_array_names = value
+
+    @property
+    def categorical_array_names(self):
+        return self._categorical_array_names
+
+    @categorical_array_names.setter
+    def categorical_array_names(self, value):
+        self._categorical_array_names = value
+
+    def data_within_interval(self, hole_id, interval):
+        pass

--- a/drilldown/layer/layer.py
+++ b/drilldown/layer/layer.py
@@ -730,7 +730,7 @@ class _IntervalLayer(_BaseLayer):
         return np.arange(self.n_intervals)
 
 
-class _DataLayer(_BaseLayer, ImageMixin, Plotting2dMixin):
+class _DataLayer(ImageMixin, _BaseLayer, Plotting2dMixin):
     def __init__(
         self,
         name,
@@ -773,6 +773,9 @@ class _DataLayer(_BaseLayer, ImageMixin, Plotting2dMixin):
 
         # to aid w resetting when switching btwn arrays of diff. types
         self.preceding_array_type = None
+
+        # active image viewer
+        self.im_viewer = None
 
     @property
     def active_array_name(self):
@@ -868,14 +871,6 @@ class _DataLayer(_BaseLayer, ImageMixin, Plotting2dMixin):
         pass
 
     @property
-    def selected_ids(self):
-        raise NotImplementedError("This method must be implemented in a subclass.")
-
-    @selected_ids.setter
-    def selected_ids(self, ids):
-        raise NotImplementedError("This method must be implemented in a subclass.")
-
-    @property
     def selected_data(self):
         ids = self.selected_ids
         data = self._process_data_output(ids)
@@ -905,10 +900,6 @@ class _DataLayer(_BaseLayer, ImageMixin, Plotting2dMixin):
         matches = data["hole ID"].isin(hole_ids)
         self.selected_ids = list(data.loc[matches].index.tolist())  # dbl list necessary
         self._selected_hole_ids = hole_ids
-
-    @property
-    def filtered_ids(self):
-        raise NotImplementedError("This method must be implemented in a subclass.")
 
     @property
     def filtered_data(self):
@@ -953,7 +944,7 @@ class _DataLayer(_BaseLayer, ImageMixin, Plotting2dMixin):
         return data
 
 
-class PointDataLayer(_PointLayer, _DataLayer):
+class PointDataLayer(_DataLayer, _PointLayer):
     def __init__(self, name, mesh, actor, plotter, *args, **kwargs):
         super().__init__(name, mesh, actor, plotter, *args, **kwargs)
 
@@ -1026,7 +1017,7 @@ class PointDataLayer(_PointLayer, _DataLayer):
         return log.fig
 
 
-class IntervalDataLayer(_IntervalLayer, _DataLayer):
+class IntervalDataLayer(_DataLayer, _IntervalLayer):
     def __init__(self, name, mesh, actor, plotter, *args, **kwargs):
         super().__init__(name, mesh, actor, plotter, *args, **kwargs)
 

--- a/drilldown/layer/layer.py
+++ b/drilldown/layer/layer.py
@@ -20,7 +20,7 @@ from ..utils import (
 )
 from ..image.image_mixin import ImageMixin
 from ..plot.plotting_mixin import Plotting2dMixin
-from ..layer.inter_layer_mixin import IntervalByMixin
+from ..layer.inter_layer_mixin import IntervalInterLayerMixin
 from ..drill_log import DrillLog
 
 
@@ -1297,7 +1297,7 @@ class PointDataLayer(_DataLayer, _PointLayer):
         return log.fig
 
 
-class IntervalDataLayer(_DataLayer, _IntervalLayer, IntervalByMixin):
+class IntervalDataLayer(_DataLayer, _IntervalLayer, IntervalInterLayerMixin):
     def __init__(self, name, mesh, actor, plotter, *args, **kwargs):
         super().__init__(name, mesh, actor, plotter, *args, **kwargs)
 

--- a/drilldown/layer/layer.py
+++ b/drilldown/layer/layer.py
@@ -762,13 +762,6 @@ class _DataLayer(_BaseLayer):
         # to aid w resetting when switching btwn arrays of diff. types
         self.preceding_array_type = None
 
-    def __getitem__(self, key):
-        return self.mesh[key]
-
-    def __setitem__(self, key, value):
-        self.mesh[key] = value
-        self.mesh.keys()
-
     @property
     def active_array_name(self):
         return self._active_array_name
@@ -937,6 +930,13 @@ class PointDataLayer(_PointLayer, _DataLayer):
     def __init__(self, name, mesh, actor, plotter, *args, **kwargs):
         super().__init__(name, mesh, actor, plotter, *args, **kwargs)
 
+    def __getitem__(self, key):
+        return self.all_data[key]
+
+    def __setitem__(self, key, value):
+        self.mesh[key] = value
+        self.active_array_name = key
+
     def _process_data_output(self, ids, array_names=[]):
         exclude = ["vtkOriginalPointIds", "vtkOriginalCellIds"]  # added by pyvista
         array_names = [name for name in self.mesh.array_names if name not in exclude]
@@ -949,6 +949,15 @@ class PointDataLayer(_PointLayer, _DataLayer):
 class IntervalDataLayer(_IntervalLayer, _DataLayer):
     def __init__(self, name, mesh, actor, plotter, *args, **kwargs):
         super().__init__(name, mesh, actor, plotter, *args, **kwargs)
+
+    def __getitem__(self, key):
+        return self.all_data[key]
+
+    def __setitem__(self, key, value):
+        cells_per_interval = self.n_sides
+        value = np.repeat(value, cells_per_interval)
+        self.mesh[key] = value
+        self.active_array_name = key
 
     def _process_data_output(self, ids, array_names=[]):
         exclude = [

--- a/drilldown/layer/layer.py
+++ b/drilldown/layer/layer.py
@@ -962,24 +962,24 @@ class PointDataLayer(_DataLayer, _PointLayer):
     def __setitem__(self, key, value):
         value, _type = convert_array_type(value, return_type=True)
         if _type == "str":  # categorical data
-            print("type is str")
-            self.categorical_array_names.append(key)
+            if key not in self.categorical_array_names:
+                self.categorical_array_names.append(key)
 
             # encode categorical data
             code_to_cat_map, value = encode_categorical_data(value)
             self.code_to_cat_map[key] = code_to_cat_map
 
         else:
-            print("type is num")
-            self.continuous_array_names.append(key)
+            if key not in self.continuous_array_names:
+                self.continuous_array_names.append(key)
 
-        print(value)
         self.mesh[key] = value
         if self.filter_actor is not None:
             self.filter_actor.mapper.dataset[key] = value[self.boolean_filter]
 
         self.active_array_name = key
-        self.array_names.append(key)
+        if key not in self.array_names:
+            self.array_names.append(key)
 
     def _process_data_output(self, ids, array_names=[]):
         exclude = ["vtkOriginalPointIds", "vtkOriginalCellIds"]  # added by pyvista
@@ -1046,7 +1046,8 @@ class IntervalDataLayer(_DataLayer, _IntervalLayer):
 
         value, _type = convert_array_type(value, return_type=True)
         if _type == "str":  # categorical data
-            self.categorical_array_names.append(key)
+            if key not in self.categorical_array_names:
+                self.categorical_array_names.append(key)
 
             # encode categorical data
             code_to_cat_map, value = encode_categorical_data(value)
@@ -1059,7 +1060,8 @@ class IntervalDataLayer(_DataLayer, _IntervalLayer):
             self.cat_to_color_map[key] = cat_to_color_map
             self.matplotlib_formatted_color_maps[key] = matplotlib_formatted_color_map
         else:
-            self.continuous_array_names.append(key)
+            if key not in self.continuous_array_names:
+                self.continuous_array_names.append(key)
 
         self.mesh[key] = value
         if self.filter_actor is not None:
@@ -1067,7 +1069,8 @@ class IntervalDataLayer(_DataLayer, _IntervalLayer):
             self.filter_actor.mapper.dataset[key] = value[boolean_filter]
 
         self.active_array_name = key
-        self.array_names.append(key)
+        if key not in self.array_names:
+            self.array_names.append(key)
 
     def _make_selection_by_dbl_click_pick(self, pos, actor):
         if actor == self.actor:

--- a/drilldown/layer/layer.py
+++ b/drilldown/layer/layer.py
@@ -20,6 +20,7 @@ from ..utils import (
 )
 from ..image.image_mixin import ImageMixin
 from ..plot.plotting_mixin import Plotting2dMixin
+from ..layer.inter_layer_mixin import IntervalByMixin
 from ..drill_log import DrillLog
 
 
@@ -1296,7 +1297,7 @@ class PointDataLayer(_DataLayer, _PointLayer):
         return log.fig
 
 
-class IntervalDataLayer(_DataLayer, _IntervalLayer):
+class IntervalDataLayer(_DataLayer, _IntervalLayer, IntervalByMixin):
     def __init__(self, name, mesh, actor, plotter, *args, **kwargs):
         super().__init__(name, mesh, actor, plotter, *args, **kwargs)
 

--- a/drilldown/layer/layer.py
+++ b/drilldown/layer/layer.py
@@ -277,12 +277,27 @@ class _PointLayer(_BaseLayer):
                     self.point_size * self.rel_selected_point_size
                 )
 
+            if len(self.plotter._active_selections_and_filters) == 0:
+                self.plotter._active_selections_and_filters.append(
+                    {f"{self.name}": "selection"}
+                )
+            elif self.plotter._active_selections_and_filters[-1] != {
+                f"{self.name}": "selection"
+            }:
+                self.plotter._active_selections_and_filters.append(
+                    {f"{self.name}": "selection"}
+                )
+
     def _reset_selection(self):
         self._picked_point = None
         self.selected_points = []
 
         self.plotter.remove_actor(self._selection_actor)
         self._selection_actor = None
+
+        self.plotter._active_selections_and_filters = (
+            self.plotter._active_selections_and_filters[:-1]
+        )
 
     @property
     def picked_point(self):
@@ -370,6 +385,17 @@ class _PointLayer(_BaseLayer):
             self.opacity = self.opacity
             self.visibility = self.visibility
 
+            if len(self.plotter._active_selections_and_filters) == 0:
+                self.plotter._active_selections_and_filters.append(
+                    {f"{self.name}": "filter"}
+                )
+            elif self.plotter._active_selections_and_filters[-1] != {
+                f"{self.name}": "filter"
+            }:
+                self.plotter._active_selections_and_filters.append(
+                    {f"{self.name}": "filter"}
+                )
+
     def _reset_filter(self):
         self._filtered_points = []
         self.plotter.remove_actor(self._filter_actor)
@@ -380,6 +406,10 @@ class _PointLayer(_BaseLayer):
 
         # return previously filtered out intervals to original opacity
         self.opacity = self.opacity
+
+        self.plotter._active_selections_and_filters = (
+            self.plotter._active_selections_and_filters[:-1]
+        )
 
     def convert_selection_to_filter(self):
         boolean_filter = np.isin(np.arange(self.n_points), self.selected_points)
@@ -645,6 +675,17 @@ class _IntervalLayer(_BaseLayer):
                     )
                     self.plotter.render()
 
+            if len(self.plotter._active_selections_and_filters) == 0:
+                self.plotter._active_selections_and_filters.append(
+                    {f"{self.name}": "selection"}
+                )
+            elif self.plotter._active_selections_and_filters[-1] != {
+                f"{self.name}": "selection"
+            }:
+                self.plotter._active_selections_and_filters.append(
+                    {f"{self.name}": "selection"}
+                )
+
     def _reset_selection(self):
         self._picked_cell = None
         self._selected_cells = []
@@ -652,6 +693,10 @@ class _IntervalLayer(_BaseLayer):
 
         self.plotter.remove_actor(self._selection_actor)
         self._selection_actor = None
+
+        self.plotter._active_selections_and_filters = (
+            self.plotter._active_selections_and_filters[:-1]
+        )
 
     @property
     def boolean_filter(self):
@@ -715,6 +760,17 @@ class _IntervalLayer(_BaseLayer):
             self.opacity = self.opacity
             self.visibility = self.visibility
 
+            if len(self.plotter._active_selections_and_filters) == 0:
+                self.plotter._active_selections_and_filters.append(
+                    {f"{self.name}": "filter"}
+                )
+            elif self.plotter._active_selections_and_filters[-1] != {
+                f"{self.name}": "filter"
+            }:
+                self.plotter._active_selections_and_filters.append(
+                    {f"{self.name}": "filter"}
+                )
+
     def _reset_filter(self):
         self._filtered_cells = []
         self._filtered_intervals = []
@@ -726,6 +782,10 @@ class _IntervalLayer(_BaseLayer):
 
         # return previously filtered out intervals to original opacity
         self.opacity = self.opacity
+
+        self.plotter._active_selections_and_filters = (
+            self.plotter._active_selections_and_filters[:-1]
+        )
 
     def convert_selection_to_filter(self):
         boolean_filter = np.isin(np.arange(self.n_intervals), self.selected_intervals)

--- a/drilldown/layer/layer.py
+++ b/drilldown/layer/layer.py
@@ -289,7 +289,7 @@ class _PointLayer(_BaseLayer):
                 )
 
     def _reset_selection(self):
-        if len(self.selected_ids) > 0: 
+        if len(self.selected_ids) > 0:
             self._picked_point = None
             self.selected_points = []
 
@@ -398,7 +398,7 @@ class _PointLayer(_BaseLayer):
                 )
 
     def _reset_filter(self):
-        if len(self.filtered_ids) > 0: 
+        if len(self.filtered_ids) > 0:
             self._filtered_points = []
             self.plotter.remove_actor(self._filter_actor)
             self._filter_actor = None
@@ -835,8 +835,15 @@ class _DataLayer(ImageMixin, _BaseLayer, Plotting2dMixin):
                     self.state.cmap = self._cmap
 
             self._clim_range = self._calculate_clim_range(self._active_array_name)
-            clim_step = (self._clim_range[1] - self._clim_range[0]) / 1000
-            self._clim_step = round_to_sig_figs(clim_step, 2)
+
+            if self._clim_range[1] - self._clim_range[0] > 1000:
+                clim_step = 1
+
+            else:
+                clim_step = (self._clim_range[1] - self._clim_range[0]) / 1000
+                clim_step = round_to_sig_figs(clim_step, 2)
+
+            self._clim_step = clim_step
             self._clim = actor.mapper.lookup_table.scalar_range
 
             if self.name == self.state.ctrl_mesh_name:
@@ -1019,8 +1026,14 @@ class _DataLayer(ImageMixin, _BaseLayer, Plotting2dMixin):
             self.clim = tuple(clim)
 
         # update clim_step
-        clim_step = (value[1] - value[0]) / 1000
-        self._clim_step = round_to_sig_figs(clim_step, 2)
+        if self._clim_range[1] - self._clim_range[0] > 1000:
+            clim_step = 1
+
+        else:
+            clim_step = (value[1] - value[0]) / 1000
+            clim_step = round_to_sig_figs(clim_step, 2)
+
+        self._clim_step = clim_step
 
         if self.name == self.state.ctrl_mesh_name:
             with self.state:
@@ -1059,8 +1072,14 @@ class _DataLayer(ImageMixin, _BaseLayer, Plotting2dMixin):
         clim_range = self._calculate_clim_range(self.active_array_name)
 
         # reset clim_step
-        clim_step = (clim_range[1] - clim_range[0]) / 1000
-        self._clim_step = round_to_sig_figs(clim_step, 2)
+        if self._clim_range[1] - self._clim_range[0] > 1000:
+            clim_step = 1
+
+        else:
+            clim_step = (clim_range[1] - clim_range[0]) / 1000
+            clim_step = round_to_sig_figs(clim_step, 2)
+
+        self._clim_step = clim_step
 
         if self.name == self.state.ctrl_mesh_name:
             with self.state:

--- a/drilldown/layer/layer.py
+++ b/drilldown/layer/layer.py
@@ -393,7 +393,7 @@ class _PointLayer(_BaseLayer):
             self._reset_filter()
 
     @property
-    def all_ids(self):
+    def ids(self):
         return np.arange(self.n_points)
 
 
@@ -740,7 +740,7 @@ class _IntervalLayer(_BaseLayer):
             self._reset_filter()
 
     @property
-    def all_ids(self):
+    def ids(self):
         return np.arange(self.n_intervals)
 
 
@@ -1060,7 +1060,7 @@ class _DataLayer(ImageMixin, _BaseLayer, Plotting2dMixin):
 
     @property
     def selected_hole_ids(self):
-        data = self.all_data
+        data = self.data
         hole_ids = data["hole ID"][self.selected_ids]
         hole_ids = list(hole_ids.unique().tolist())  # dbl list necessary
 
@@ -1074,7 +1074,7 @@ class _DataLayer(ImageMixin, _BaseLayer, Plotting2dMixin):
         if not isinstance(hole_ids, (list, np.ndarray, pd.Series)):
             raise ValueError("hole_ids must be a list, numpy array, or pandas Series.")
 
-        data = self.all_data
+        data = self.data
         if self.filter_actor is not None:
             data = data[self.boolean_filter]
 
@@ -1091,18 +1091,25 @@ class _DataLayer(ImageMixin, _BaseLayer, Plotting2dMixin):
 
     @property
     def filtered_hole_ids(self):
-        data = self.all_data
+        data = self.data
         hole_ids = data["hole ID"][self.filtered_ids]
         hole_ids = hole_ids.unique().tolist()
 
         return hole_ids
 
     @property
-    def all_data(self):
-        ids = self.all_ids
+    def data(self):
+        ids = self.ids
         data = self._process_data_output(ids)
 
         return data
+
+    @property
+    def hole_ids(self):
+        data = self.data
+        hole_ids = data["hole ID"].unique().tolist()
+
+        return hole_ids
 
     def _process_data_output(self, ids, array_names=[], step=1):
         if len(array_names) == 0:
@@ -1127,7 +1134,7 @@ class PointDataLayer(_DataLayer, _PointLayer):
         super().__init__(name, mesh, actor, plotter, *args, **kwargs)
 
     def __getitem__(self, key):
-        return self.all_data[key]
+        return self.data[key]
 
     def __setitem__(self, key, value):
         value, _type = convert_array_type(value, return_type=True)
@@ -1211,7 +1218,7 @@ class IntervalDataLayer(_DataLayer, _IntervalLayer):
         super().__init__(name, mesh, actor, plotter, *args, **kwargs)
 
     def __getitem__(self, key):
-        return self.all_data[key]
+        return self.data[key]
 
     def __setitem__(self, key, value):
         cells_per_interval = self.n_sides

--- a/drilldown/layer/layer.py
+++ b/drilldown/layer/layer.py
@@ -978,7 +978,6 @@ class PointDataLayer(_DataLayer, _PointLayer):
         if self.filter_actor is not None:
             self.filter_actor.mapper.dataset[key] = value[self.boolean_filter]
 
-        self.active_array_name = key
         if key not in self.array_names:
             self.array_names.append(key)
 
@@ -1069,7 +1068,6 @@ class IntervalDataLayer(_DataLayer, _IntervalLayer):
             boolean_filter = np.repeat(self.boolean_filter, cells_per_interval)
             self.filter_actor.mapper.dataset[key] = value[boolean_filter]
 
-        self.active_array_name = key
         if key not in self.array_names:
             self.array_names.append(key)
 

--- a/drilldown/layer/layer.py
+++ b/drilldown/layer/layer.py
@@ -243,26 +243,27 @@ class _PointLayer(_BaseLayer):
         pass  # not trivial as cell IDs are not inherently sequential along hole
 
     def _update_selection_object(self):
-        selection_mesh = self.mesh.extract_points(self.selected_points)
-        if (selection_mesh.n_points != 0) and (selection_mesh.n_cells != 0):
-            selection_actor = self.actor.copy(deep=True)
-            selection_actor.mapper.dataset = selection_mesh
+        if len(self.selected_points) != 0:
+            selection_mesh = self.mesh.extract_points(self.selected_points)
+            if (selection_mesh.n_points != 0) and (selection_mesh.n_cells != 0):
+                selection_actor = self.actor.copy(deep=True)
+                selection_actor.mapper.dataset = selection_mesh
 
-            self.plotter.add_actor(
-                selection_actor,
-                name=self.name + " selection",
-                pickable=False,
-                reset_camera=False,
-            )
+                self.plotter.add_actor(
+                    selection_actor,
+                    name=self.name + " selection",
+                    pickable=False,
+                    reset_camera=False,
+                )
 
-            self._selection_actor = selection_actor
+                self._selection_actor = selection_actor
 
-            # update selection actor properties
-            self.selection_color = self.selection_color
-            self.opacity = self.opacity
-            selection_actor.prop.point_size = (
-                self.point_size * self.rel_selected_point_size
-            )
+                # update selection actor properties
+                self.selection_color = self.selection_color
+                self.opacity = self.opacity
+                selection_actor.prop.point_size = (
+                    self.point_size * self.rel_selected_point_size
+                )
 
     def _reset_selection(self):
         self._picked_point = None
@@ -613,23 +614,24 @@ class _IntervalLayer(_BaseLayer):
         self.selected_intervals = ids
 
     def _update_selection_object(self):
-        selection_mesh = self.mesh.extract_cells(self._selected_cells)
-        if (selection_mesh.n_points != 0) and (selection_mesh.n_cells != 0):
-            selection_actor = self.plotter.add_mesh(
-                selection_mesh,
-                name=self.name + " selection",
-                color=self.selection_color,
-                opacity=self.opacity * self.rel_selection_opacity,
-                reset_camera=False,
-                pickable=False,
-            )
-            self._selection_actor = selection_actor
-
-            if selection_actor is not None:
-                selection_actor.mapper.SetRelativeCoincidentTopologyPolygonOffsetParameters(
-                    0, -6
+        if len(self._selected_cells) != 0:
+            selection_mesh = self.mesh.extract_cells(self._selected_cells)
+            if (selection_mesh.n_points != 0) and (selection_mesh.n_cells != 0):
+                selection_actor = self.plotter.add_mesh(
+                    selection_mesh,
+                    name=self.name + " selection",
+                    color=self.selection_color,
+                    opacity=self.opacity * self.rel_selection_opacity,
+                    reset_camera=False,
+                    pickable=False,
                 )
-                self.plotter.render()
+                self._selection_actor = selection_actor
+
+                if selection_actor is not None:
+                    selection_actor.mapper.SetRelativeCoincidentTopologyPolygonOffsetParameters(
+                        0, -6
+                    )
+                    self.plotter.render()
 
     def _reset_selection(self):
         self._picked_cell = None

--- a/drilldown/layer/layer.py
+++ b/drilldown/layer/layer.py
@@ -289,15 +289,16 @@ class _PointLayer(_BaseLayer):
                 )
 
     def _reset_selection(self):
-        self._picked_point = None
-        self.selected_points = []
+        if len(self.selected_ids) > 0: 
+            self._picked_point = None
+            self.selected_points = []
 
-        self.plotter.remove_actor(self._selection_actor)
-        self._selection_actor = None
+            self.plotter.remove_actor(self._selection_actor)
+            self._selection_actor = None
 
-        self.plotter._active_selections_and_filters = (
-            self.plotter._active_selections_and_filters[:-1]
-        )
+            self.plotter._active_selections_and_filters = (
+                self.plotter._active_selections_and_filters[:-1]
+            )
 
     @property
     def picked_point(self):
@@ -397,19 +398,20 @@ class _PointLayer(_BaseLayer):
                 )
 
     def _reset_filter(self):
-        self._filtered_points = []
-        self.plotter.remove_actor(self._filter_actor)
-        self._filter_actor = None
+        if len(self.filtered_ids) > 0: 
+            self._filtered_points = []
+            self.plotter.remove_actor(self._filter_actor)
+            self._filter_actor = None
 
-        # make previously filtered out intervals pickable
-        self.actor.SetPickable(True)
+            # make previously filtered out intervals pickable
+            self.actor.SetPickable(True)
 
-        # return previously filtered out intervals to original opacity
-        self.opacity = self.opacity
+            # return previously filtered out intervals to original opacity
+            self.opacity = self.opacity
 
-        self.plotter._active_selections_and_filters = (
-            self.plotter._active_selections_and_filters[:-1]
-        )
+            self.plotter._active_selections_and_filters = (
+                self.plotter._active_selections_and_filters[:-1]
+            )
 
     def convert_selection_to_filter(self):
         boolean_filter = np.isin(np.arange(self.n_points), self.selected_points)
@@ -687,16 +689,17 @@ class _IntervalLayer(_BaseLayer):
                 )
 
     def _reset_selection(self):
-        self._picked_cell = None
-        self._selected_cells = []
-        self.selected_intervals = []
+        if len(self.selected_ids) > 0:
+            self._picked_cell = None
+            self._selected_cells = []
+            self.selected_intervals = []
 
-        self.plotter.remove_actor(self._selection_actor)
-        self._selection_actor = None
+            self.plotter.remove_actor(self._selection_actor)
+            self._selection_actor = None
 
-        self.plotter._active_selections_and_filters = (
-            self.plotter._active_selections_and_filters[:-1]
-        )
+            self.plotter._active_selections_and_filters = (
+                self.plotter._active_selections_and_filters[:-1]
+            )
 
     @property
     def boolean_filter(self):
@@ -772,20 +775,21 @@ class _IntervalLayer(_BaseLayer):
                 )
 
     def _reset_filter(self):
-        self._filtered_cells = []
-        self._filtered_intervals = []
-        self.plotter.remove_actor(self._filter_actor)
-        self._filter_actor = None
+        if len(self.filtered_ids) > 0:
+            self._filtered_cells = []
+            self._filtered_intervals = []
+            self.plotter.remove_actor(self._filter_actor)
+            self._filter_actor = None
 
-        # make previously filtered out intervals pickable
-        self.actor.SetPickable(True)
+            # make previously filtered out intervals pickable
+            self.actor.SetPickable(True)
 
-        # return previously filtered out intervals to original opacity
-        self.opacity = self.opacity
+            # return previously filtered out intervals to original opacity
+            self.opacity = self.opacity
 
-        self.plotter._active_selections_and_filters = (
-            self.plotter._active_selections_and_filters[:-1]
-        )
+            self.plotter._active_selections_and_filters = (
+                self.plotter._active_selections_and_filters[:-1]
+            )
 
     def convert_selection_to_filter(self):
         boolean_filter = np.isin(np.arange(self.n_intervals), self.selected_intervals)

--- a/drilldown/layer/layer_list.py
+++ b/drilldown/layer/layer_list.py
@@ -1,0 +1,11 @@
+class LayerList(list):
+    def __getitem__(self, value):
+        if isinstance(value, str):
+            for layer in self:
+                if layer.name == value:
+                    return layer
+
+            return None
+
+        else:
+            return super().__getitem__(value)

--- a/drilldown/plot/plotly_plots.py
+++ b/drilldown/plot/plotly_plots.py
@@ -7,13 +7,19 @@ from trame.ui.vuetify import SinglePageLayout
 
 from plotly import express as px
 import numpy as np
+import uuid
+
 
 from ..utils import convert_to_numpy_array, is_jupyter
 
 
 class PlotlyPlot:
-    def __init__(self, server=None, *args, **kwargs):
-        self.name = "plotly"
+    def __init__(self, name=None, server=None, *args, **kwargs):
+        if name is not None:
+            self.name = name
+        else:
+            self.name = str(uuid.uuid4())
+
         if server is not None:
             self.server = server
         else:
@@ -29,7 +35,7 @@ class PlotlyPlot:
         self.ids = None
         self.selected_ids = None
 
-        self.plotter = None
+        self.layer = None
 
     def show(self, inline=True):
         if inline == True:
@@ -88,16 +94,14 @@ class PlotlyPlot:
         if ids is not None:
             self.selected_ids = ids
 
-            if self.plotter is not None:
-                name = self.actor_name
-                self.plotter.selected_intervals = (name, np.array(self.ids)[ids])
+            if self.layer is not None:
+                self.layer.selected_ids = np.array(self.ids)[ids]
 
     def _on_plot_deselection(self, event):
         self.selected_ids = None
 
-        if self.plotter is not None:
-            name = self.actor_name
-            self.plotter.selected_intervals = (name, np.array(self.ids))
+        if self.layer is not None:
+            self.layer.selected_ids = np.array(self.ids)
 
     def _on_scatter_plot_click(self, ids):
         pass

--- a/drilldown/plot/plotly_plots.py
+++ b/drilldown/plot/plotly_plots.py
@@ -119,6 +119,15 @@ class ScatterPlot(PlotlyPlot):
         self.ctrl.plotly_plot_view_update(fig)
 
 
+class Scatter3dPlot(PlotlyPlot):
+    def __init__(self, data, x, y, z, **kwargs):
+        super().__init__()
+        self.data = data
+        fig = px.scatter_3d(data, x=x, y=y, z=z, **kwargs)
+        self.fig = fig
+        self.ctrl.plotly_plot_view_update(fig)
+
+
 class ScatterTernaryPlot(PlotlyPlot):
     def __init__(self, data, a, b, c, **kwargs):
         server = kwargs.get("server", None)

--- a/drilldown/plot/plotly_plots.py
+++ b/drilldown/plot/plotly_plots.py
@@ -14,7 +14,7 @@ from ..utils import convert_to_numpy_array, is_jupyter
 
 
 class PlotlyPlot:
-    def __init__(self, name=None, server=None, *args, **kwargs):
+    def __init__(self, name=None, server=None):
         if name is not None:
             self.name = name
         else:
@@ -38,6 +38,7 @@ class PlotlyPlot:
         self.layer = None
 
     def show(self, inline=True):
+        self.update()
         if inline == True:
             if is_jupyter():
                 elegantly_launch(self.server)  # launch server in nb w/o using await
@@ -106,8 +107,8 @@ class PlotlyPlot:
     def _on_scatter_plot_click(self, ids):
         pass
 
-    def reset_resolution(self, app):
-        app.reset_resolution()
+    def update(self, *args, **kwargs):
+        self.ctrl.plotly_plot_view_update(*args, **kwargs)
 
 
 class ScatterPlot(PlotlyPlot):
@@ -116,7 +117,7 @@ class ScatterPlot(PlotlyPlot):
         self.data = data
         fig = px.scatter(data, x=x, y=y, **kwargs)
         self.fig = fig
-        self.ctrl.plotly_plot_view_update(fig)
+        self.update(fig)
 
 
 class Scatter3dPlot(PlotlyPlot):
@@ -125,7 +126,7 @@ class Scatter3dPlot(PlotlyPlot):
         self.data = data
         fig = px.scatter_3d(data, x=x, y=y, z=z, **kwargs)
         self.fig = fig
-        self.ctrl.plotly_plot_view_update(fig)
+        self.update(fig)
 
 
 class ScatterTernaryPlot(PlotlyPlot):
@@ -137,7 +138,7 @@ class ScatterTernaryPlot(PlotlyPlot):
         self.data = data
         fig = px.scatter_ternary(data, a=a, b=b, c=c, **kwargs)
         self.fig = fig
-        self.ctrl.plotly_plot_view_update(fig)
+        self.update(fig)
 
 
 class ScatterDimensionsPlot(PlotlyPlot):
@@ -149,7 +150,7 @@ class ScatterDimensionsPlot(PlotlyPlot):
         self.data = data
         fig = px.scatter_matrix(data, dimensions=dimensions, **kwargs)
         self.fig = fig
-        self.ctrl.plotly_plot_view_update(fig)
+        self.update(fig)
 
 
 class BarPlot(PlotlyPlot):
@@ -158,7 +159,7 @@ class BarPlot(PlotlyPlot):
         self.data = data
         fig = px.bar(data, x=x, y=y, **kwargs)
         self.fig = fig
-        self.ctrl.plotly_plot_view_update(fig)
+        self.update(fig)
 
 
 class Histogram(PlotlyPlot):
@@ -167,4 +168,4 @@ class Histogram(PlotlyPlot):
         self.data = data
         fig = px.histogram(data, x=x, **kwargs)
         self.fig = fig
-        self.ctrl.plotly_plot_view_update(fig)
+        self.update(fig)

--- a/drilldown/plot/plotly_plots.py
+++ b/drilldown/plot/plotly_plots.py
@@ -35,7 +35,7 @@ class PlotlyPlot:
         self.ids = None
         self.selected_ids = None
 
-        self.layer = None
+        self._layer = None
 
     def show(self, inline=True):
         self.update()
@@ -91,6 +91,25 @@ class PlotlyPlot:
 
         return layout
 
+    @property
+    def layer(self):
+        return self._layer
+
+    @property
+    def layer_relationship(self):
+        return self._layer_relationship
+
+    def connect_layer(self, layer, relationship=None):
+        if relationship is not None:
+            if relationship not in ["selected", "filtered"]:
+                raise ValueError(
+                    "Relationship must be 'selected', 'filtered', or None."
+                )
+
+        self._layer = layer
+        self._layer.plot = self
+        self._layer_relationship = relationship
+
     def _on_plot_selection(self, ids):
         if ids is not None:
             self.selected_ids = ids
@@ -102,7 +121,10 @@ class PlotlyPlot:
         self.selected_ids = None
 
         if self.layer is not None:
-            self.layer.selected_ids = np.array(self.ids)
+            if self.layer_relationship == "selected":
+                self.layer.selected_ids = np.array(self.ids)
+            else:
+                self.layer._reset_selection()
 
     def _on_scatter_plot_click(self, ids):
         pass

--- a/drilldown/plot/plotly_plots.py
+++ b/drilldown/plot/plotly_plots.py
@@ -8,22 +8,7 @@ from trame.ui.vuetify import SinglePageLayout
 from plotly import express as px
 import numpy as np
 
-from ..utils import convert_to_numpy_array
-
-
-def is_jupyter():
-    from IPython import get_ipython
-
-    try:
-        shell = get_ipython().__class__.__name__
-        if shell == "ZMQInteractiveShell":
-            return True  # Jupyter notebook or qtconsole
-        elif shell == "TerminalInteractiveShell":
-            return False  # Terminal running IPython
-        else:
-            return False  # Other type (?)
-    except NameError:
-        return False
+from ..utils import convert_to_numpy_array, is_jupyter
 
 
 class PlotlyPlot:

--- a/drilldown/plot/plotting_mixin.py
+++ b/drilldown/plot/plotting_mixin.py
@@ -12,7 +12,7 @@ class Plotting2dMixin:
 
         return fig
 
-    def selected_scatter_plot(self, x, y, **kwargs):
+    def scatter_plot_from_selection(self, x, y, **kwargs):
         from .plotly_plots import ScatterPlot
 
         fig = ScatterPlot(self.selected_data, x, y, **kwargs)
@@ -22,7 +22,7 @@ class Plotting2dMixin:
 
         return fig
 
-    def filtered_scatter_plot(self, x, y, **kwargs):
+    def scatter_plot_from_filter(self, x, y, **kwargs):
         from .plotly_plots import ScatterPlot
 
         fig = ScatterPlot(self.filtered_data, x, y, **kwargs)
@@ -42,7 +42,7 @@ class Plotting2dMixin:
 
         return fig
 
-    def selected_scatter_3d_plot(self, x, y, z, **kwargs):
+    def scatter_3d_plot_from_selection(self, x, y, z, **kwargs):
         from .plotly_plots import Scatter3dPlot
 
         fig = Scatter3dPlot(self.selected_data, x, y, z, **kwargs)
@@ -52,7 +52,7 @@ class Plotting2dMixin:
 
         return fig
 
-    def filtered_scatter_3d_plot(self, x, y, z, **kwargs):
+    def scatter_3d_plot_from_filter(self, x, y, z, **kwargs):
         from .plotly_plots import Scatter3dPlot
 
         fig = Scatter3dPlot(self.filtered_data, x, y, z, **kwargs)
@@ -72,7 +72,7 @@ class Plotting2dMixin:
 
         return fig
 
-    def selected_scatter_ternary_plot(self, a, b, c, **kwargs):
+    def scatter_ternary_plot_from_selection(self, a, b, c, **kwargs):
         from .plotly_plots import ScatterTernaryPlot
 
         fig = ScatterTernaryPlot(self.selected_data, a, b, c, **kwargs)
@@ -84,7 +84,7 @@ class Plotting2dMixin:
 
         return fig
 
-    def filtered_scatter_ternary_plot(self, a, b, c, **kwargs):
+    def scatter_ternary_plot_from_filter(self, a, b, c, **kwargs):
         from .plotly_plots import ScatterTernaryPlot
 
         fig = ScatterTernaryPlot(self.filtered_data, a, b, c, **kwargs)
@@ -106,7 +106,7 @@ class Plotting2dMixin:
 
         return fig
 
-    def selected_scatter_dimensions_plot(self, dimensions, **kwargs):
+    def scatter_dimensions_plot_from_selection(self, dimensions, **kwargs):
         from .plotly_plots import ScatterDimensionsPlot
 
         fig = ScatterDimensionsPlot(self.selected_data, dimensions, **kwargs)
@@ -118,7 +118,7 @@ class Plotting2dMixin:
 
         return fig
 
-    def filtered_scatter_dimensions_plot(self, dimensions, **kwargs):
+    def scatter_dimensions_plot_from_filter(self, dimensions, **kwargs):
         from .plotly_plots import ScatterDimensionsPlot
 
         fig = ScatterDimensionsPlot(self.filtered_data, dimensions, **kwargs)
@@ -140,7 +140,7 @@ class Plotting2dMixin:
 
         return fig
 
-    def selected_bar_plot(self, x, y, **kwargs):
+    def bar_plot_from_selection(self, x, y, **kwargs):
         from .plotly_plots import BarPlot
 
         fig = BarPlot(self.selected_data, x, y, **kwargs)
@@ -152,7 +152,7 @@ class Plotting2dMixin:
 
         return fig
 
-    def filtered_bar_plot(self, x, y, **kwargs):
+    def bar_plot_from_filter(self, x, y, **kwargs):
         from .plotly_plots import BarPlot
 
         fig = BarPlot(self.filtered_data, x, y, **kwargs)
@@ -174,7 +174,7 @@ class Plotting2dMixin:
 
         return fig
 
-    def selected_histogram(self, x, **kwargs):
+    def histogram_from_selection(self, x, **kwargs):
         from .plotly_plots import Histogram
 
         fig = Histogram(self.selected_data, x, **kwargs)
@@ -186,7 +186,7 @@ class Plotting2dMixin:
 
         return fig
 
-    def filtered_histogram(self, x, **kwargs):
+    def histogram_from_filter(self, x, **kwargs):
         from .plotly_plots import Histogram
 
         fig = Histogram(self.filtered_data, x, **kwargs)

--- a/drilldown/plot/plotting_mixin.py
+++ b/drilldown/plot/plotting_mixin.py
@@ -12,6 +12,16 @@ class Plotting2dMixin:
 
         return fig
 
+    def selected_scatter_3d_plot(self, x, y, z, **kwargs):
+        from .plotly_plots import Scatter3dPlot
+
+        fig = Scatter3dPlot(self.selected_data, x, y, z, **kwargs)
+
+        fig.layer = self
+        fig.ids = self.selected_ids
+
+        return fig
+
     def selected_scatter_ternary_plot(self, a, b, c, **kwargs):
         from .plotly_plots import ScatterTernaryPlot
 

--- a/drilldown/plot/plotting_mixin.py
+++ b/drilldown/plot/plotting_mixin.py
@@ -5,69 +5,57 @@ class Plotting2dMixin:
     def selected_scatter_plot(self, x, y, **kwargs):
         from .plotly_plots import ScatterPlot
 
-        fig = ScatterPlot(self.selected_data(), x, y, **kwargs)
+        fig = ScatterPlot(self.selected_data, x, y, **kwargs)
 
-        fig.plotter = self
-        fig.actor_name = self.selection_actor_name.split(" ")[0]
-        if fig.actor_name in self.interval_actor_names:
-            fig.ids = self.selected_intervals
-        elif fig.actor_name in self.point_actor_names:
-            fig.ids = self.selected_points
+        fig.layer = self
+        fig.ids = self.selected_ids
 
         return fig
 
     def selected_scatter_ternary_plot(self, a, b, c, **kwargs):
         from .plotly_plots import ScatterTernaryPlot
 
-        fig = ScatterTernaryPlot(self.selected_data(), a, b, c, **kwargs)
+        fig = ScatterTernaryPlot(self.selected_data, a, b, c, **kwargs)
 
         fig.plotter = self
-        fig.actor_name = self.selection_actor_name.split(" ")[0]
-        if fig.actor_name in self.interval_actor_names:
-            fig.ids = self.selected_intervals
-        elif fig.actor_name in self.point_actor_names:
-            fig.ids = self.selected_points
+
+        fig.layer = self
+        fig.ids = self.selected_ids
 
         return fig
 
     def selected_scatter_dimensions_plot(self, dimensions, **kwargs):
         from .plotly_plots import ScatterDimensionsPlot
 
-        fig = ScatterDimensionsPlot(self.selected_data(), dimensions, **kwargs)
+        fig = ScatterDimensionsPlot(self.selected_data, dimensions, **kwargs)
 
         fig.plotter = self
-        fig.actor_name = self.selection_actor_name.split(" ")[0]
-        if fig.actor_name in self.interval_actor_names:
-            fig.ids = self.selected_intervals
-        elif fig.actor_name in self.point_actor_names:
-            fig.ids = self.selected_points
+
+        fig.layer = self
+        fig.ids = self.selected_ids
 
         return fig
 
     def selected_bar_plot(self, x, y, **kwargs):
         from .plotly_plots import BarPlot
 
-        fig = BarPlot(self.selected_data(), x, y, **kwargs)
+        fig = BarPlot(self.selected_data, x, y, **kwargs)
 
         fig.plotter = self
-        fig.actor_name = self.selection_actor_name.split(" ")[0]
-        if fig.actor_name in self.interval_actor_names:
-            fig.ids = self.selected_intervals
-        elif fig.actor_name in self.point_actor_names:
-            fig.ids = self.selected_points
+
+        fig.layer = self
+        fig.ids = self.selected_ids
 
         return fig
 
     def selected_histogram(self, x, **kwargs):
         from .plotly_plots import Histogram
 
-        fig = Histogram(self.selected_data(), x, **kwargs)
+        fig = Histogram(self.selected_data, x, **kwargs)
 
         fig.plotter = self
-        fig.actor_name = self.selection_actor_name.split(" ")[0]
-        if fig.actor_name in self.interval_actor_names:
-            fig.ids = self.selected_intervals
-        elif fig.actor_name in self.point_actor_names:
-            fig.ids = self.selected_points
+
+        fig.layer = self
+        fig.ids = self.selected_ids
 
         return fig

--- a/drilldown/plot/plotting_mixin.py
+++ b/drilldown/plot/plotting_mixin.py
@@ -7,7 +7,7 @@ class Plotting2dMixin:
 
         fig = ScatterPlot(self.data, x, y, **kwargs)
 
-        fig.layer = self
+        fig.connect_layer(self)
         fig.ids = self.ids
 
         return fig
@@ -17,7 +17,7 @@ class Plotting2dMixin:
 
         fig = ScatterPlot(self.selected_data, x, y, **kwargs)
 
-        fig.layer = self
+        fig.connect_layer(self, relationship="selected")
         fig.ids = self.selected_ids
 
         return fig
@@ -27,7 +27,7 @@ class Plotting2dMixin:
 
         fig = ScatterPlot(self.filtered_data, x, y, **kwargs)
 
-        fig.layer = self
+        fig.connect_layer(self, relationship="filtered")
         fig.ids = self.filtered_ids
 
         return fig
@@ -37,7 +37,7 @@ class Plotting2dMixin:
 
         fig = Scatter3dPlot(self.data, x, y, z, **kwargs)
 
-        fig.layer = self
+        fig.connect_layer(self)
         fig.ids = self.ids
 
         return fig
@@ -47,7 +47,7 @@ class Plotting2dMixin:
 
         fig = Scatter3dPlot(self.selected_data, x, y, z, **kwargs)
 
-        fig.layer = self
+        fig.connect_layer(self, relationship="selected")
         fig.ids = self.selected_ids
 
         return fig
@@ -57,7 +57,7 @@ class Plotting2dMixin:
 
         fig = Scatter3dPlot(self.filtered_data, x, y, z, **kwargs)
 
-        fig.layer = self
+        fig.connect_layer(self, relationship="filtered")
         fig.ids = self.filtered_ids
 
         return fig
@@ -67,7 +67,7 @@ class Plotting2dMixin:
 
         fig = ScatterTernaryPlot(self.data, a, b, c, **kwargs)
 
-        fig.layer = self
+        fig.connect_layer(self)
         fig.ids = self.ids
 
         return fig
@@ -79,7 +79,7 @@ class Plotting2dMixin:
 
         fig.plotter = self
 
-        fig.layer = self
+        fig.connect_layer(self, relationship="selected")
         fig.ids = self.selected_ids
 
         return fig
@@ -91,7 +91,7 @@ class Plotting2dMixin:
 
         fig.plotter = self
 
-        fig.layer = self
+        fig.connect_layer(self, relationship="filtered")
         fig.ids = self.filtered_ids
 
         return fig
@@ -101,7 +101,7 @@ class Plotting2dMixin:
 
         fig = ScatterDimensionsPlot(self.data, dimensions, **kwargs)
 
-        fig.layer = self
+        fig.connect_layer(self)
         fig.ids = self.ids
 
         return fig
@@ -113,7 +113,7 @@ class Plotting2dMixin:
 
         fig.plotter = self
 
-        fig.layer = self
+        fig.connect_layer(self, relationship="selected")
         fig.ids = self.selected_ids
 
         return fig
@@ -125,7 +125,7 @@ class Plotting2dMixin:
 
         fig.plotter = self
 
-        fig.layer = self
+        fig.connect_layer(self, relationship="filtered")
         fig.ids = self.filtered_ids
 
         return fig
@@ -135,7 +135,7 @@ class Plotting2dMixin:
 
         fig = BarPlot(self.data, x, y, **kwargs)
 
-        fig.layer = self
+        fig.connect_layer(self)
         fig.ids = self.ids
 
         return fig
@@ -147,7 +147,7 @@ class Plotting2dMixin:
 
         fig.plotter = self
 
-        fig.layer = self
+        fig.connect_layer(self, relationship="selected")
         fig.ids = self.selected_ids
 
         return fig
@@ -159,7 +159,7 @@ class Plotting2dMixin:
 
         fig.plotter = self
 
-        fig.layer = self
+        fig.connect_layer(self, relationship="filtered")
         fig.ids = self.filtered_ids
 
         return fig
@@ -169,7 +169,7 @@ class Plotting2dMixin:
 
         fig = Histogram(self.data, x, **kwargs)
 
-        fig.layer = self
+        fig.connect_layer(self)
         fig.ids = self.ids
 
         return fig
@@ -181,7 +181,7 @@ class Plotting2dMixin:
 
         fig.plotter = self
 
-        fig.layer = self
+        fig.connect_layer(self, relationship="selected")
         fig.ids = self.selected_ids
 
         return fig
@@ -193,7 +193,7 @@ class Plotting2dMixin:
 
         fig.plotter = self
 
-        fig.layer = self
+        fig.connect_layer(self, relationship="filtered")
         fig.ids = self.filtered_ids
 
         return fig

--- a/drilldown/plot/plotting_mixin.py
+++ b/drilldown/plot/plotting_mixin.py
@@ -2,6 +2,16 @@ class Plotting2dMixin:
     def __init__(self):
         pass
 
+    def scatter_plot(self, x, y, **kwargs):
+        from .plotly_plots import ScatterPlot
+
+        fig = ScatterPlot(self.all_data, x, y, **kwargs)
+
+        fig.layer = self
+        fig.ids = self.all_ids
+
+        return fig
+
     def selected_scatter_plot(self, x, y, **kwargs):
         from .plotly_plots import ScatterPlot
 
@@ -12,6 +22,26 @@ class Plotting2dMixin:
 
         return fig
 
+    def filtered_scatter_plot(self, x, y, **kwargs):
+        from .plotly_plots import ScatterPlot
+
+        fig = ScatterPlot(self.filtered_data, x, y, **kwargs)
+
+        fig.layer = self
+        fig.ids = self.filtered_ids
+
+        return fig
+
+    def scatter_3d_plot(self, x, y, z, **kwargs):
+        from .plotly_plots import Scatter3dPlot
+
+        fig = Scatter3dPlot(self.all_data, x, y, z, **kwargs)
+
+        fig.layer = self
+        fig.ids = self.all_ids
+
+        return fig
+
     def selected_scatter_3d_plot(self, x, y, z, **kwargs):
         from .plotly_plots import Scatter3dPlot
 
@@ -19,6 +49,26 @@ class Plotting2dMixin:
 
         fig.layer = self
         fig.ids = self.selected_ids
+
+        return fig
+
+    def filtered_scatter_3d_plot(self, x, y, z, **kwargs):
+        from .plotly_plots import Scatter3dPlot
+
+        fig = Scatter3dPlot(self.filtered_data, x, y, z, **kwargs)
+
+        fig.layer = self
+        fig.ids = self.filtered_ids
+
+        return fig
+
+    def scatter_ternary_plot(self, a, b, c, **kwargs):
+        from .plotly_plots import ScatterTernaryPlot
+
+        fig = ScatterTernaryPlot(self.all_data, a, b, c, **kwargs)
+
+        fig.layer = self
+        fig.ids = self.all_ids
 
         return fig
 
@@ -34,6 +84,28 @@ class Plotting2dMixin:
 
         return fig
 
+    def filtered_scatter_ternary_plot(self, a, b, c, **kwargs):
+        from .plotly_plots import ScatterTernaryPlot
+
+        fig = ScatterTernaryPlot(self.filtered_data, a, b, c, **kwargs)
+
+        fig.plotter = self
+
+        fig.layer = self
+        fig.ids = self.filtered_ids
+
+        return fig
+
+    def scatter_dimensions_plot(self, dimensions, **kwargs):
+        from .plotly_plots import ScatterDimensionsPlot
+
+        fig = ScatterDimensionsPlot(self.all_data, dimensions, **kwargs)
+
+        fig.layer = self
+        fig.ids = self.all_ids
+
+        return fig
+
     def selected_scatter_dimensions_plot(self, dimensions, **kwargs):
         from .plotly_plots import ScatterDimensionsPlot
 
@@ -43,6 +115,28 @@ class Plotting2dMixin:
 
         fig.layer = self
         fig.ids = self.selected_ids
+
+        return fig
+
+    def filtered_scatter_dimensions_plot(self, dimensions, **kwargs):
+        from .plotly_plots import ScatterDimensionsPlot
+
+        fig = ScatterDimensionsPlot(self.filtered_data, dimensions, **kwargs)
+
+        fig.plotter = self
+
+        fig.layer = self
+        fig.ids = self.filtered_ids
+
+        return fig
+
+    def bar_plot(self, x, y, **kwargs):
+        from .plotly_plots import BarPlot
+
+        fig = BarPlot(self.all_data, x, y, **kwargs)
+
+        fig.layer = self
+        fig.ids = self.all_ids
 
         return fig
 
@@ -58,6 +152,28 @@ class Plotting2dMixin:
 
         return fig
 
+    def filtered_bar_plot(self, x, y, **kwargs):
+        from .plotly_plots import BarPlot
+
+        fig = BarPlot(self.filtered_data, x, y, **kwargs)
+
+        fig.plotter = self
+
+        fig.layer = self
+        fig.ids = self.filtered_ids
+
+        return fig
+
+    def histogram(self, x, **kwargs):
+        from .plotly_plots import Histogram
+
+        fig = Histogram(self.all_data, x, **kwargs)
+
+        fig.layer = self
+        fig.ids = self.all_ids
+
+        return fig
+
     def selected_histogram(self, x, **kwargs):
         from .plotly_plots import Histogram
 
@@ -67,5 +183,17 @@ class Plotting2dMixin:
 
         fig.layer = self
         fig.ids = self.selected_ids
+
+        return fig
+
+    def filtered_histogram(self, x, **kwargs):
+        from .plotly_plots import Histogram
+
+        fig = Histogram(self.filtered_data, x, **kwargs)
+
+        fig.plotter = self
+
+        fig.layer = self
+        fig.ids = self.filtered_ids
 
         return fig

--- a/drilldown/plot/plotting_mixin.py
+++ b/drilldown/plot/plotting_mixin.py
@@ -5,10 +5,10 @@ class Plotting2dMixin:
     def scatter_plot(self, x, y, **kwargs):
         from .plotly_plots import ScatterPlot
 
-        fig = ScatterPlot(self.all_data, x, y, **kwargs)
+        fig = ScatterPlot(self.data, x, y, **kwargs)
 
         fig.layer = self
-        fig.ids = self.all_ids
+        fig.ids = self.ids
 
         return fig
 
@@ -35,10 +35,10 @@ class Plotting2dMixin:
     def scatter_3d_plot(self, x, y, z, **kwargs):
         from .plotly_plots import Scatter3dPlot
 
-        fig = Scatter3dPlot(self.all_data, x, y, z, **kwargs)
+        fig = Scatter3dPlot(self.data, x, y, z, **kwargs)
 
         fig.layer = self
-        fig.ids = self.all_ids
+        fig.ids = self.ids
 
         return fig
 
@@ -65,10 +65,10 @@ class Plotting2dMixin:
     def scatter_ternary_plot(self, a, b, c, **kwargs):
         from .plotly_plots import ScatterTernaryPlot
 
-        fig = ScatterTernaryPlot(self.all_data, a, b, c, **kwargs)
+        fig = ScatterTernaryPlot(self.data, a, b, c, **kwargs)
 
         fig.layer = self
-        fig.ids = self.all_ids
+        fig.ids = self.ids
 
         return fig
 
@@ -99,10 +99,10 @@ class Plotting2dMixin:
     def scatter_dimensions_plot(self, dimensions, **kwargs):
         from .plotly_plots import ScatterDimensionsPlot
 
-        fig = ScatterDimensionsPlot(self.all_data, dimensions, **kwargs)
+        fig = ScatterDimensionsPlot(self.data, dimensions, **kwargs)
 
         fig.layer = self
-        fig.ids = self.all_ids
+        fig.ids = self.ids
 
         return fig
 
@@ -133,10 +133,10 @@ class Plotting2dMixin:
     def bar_plot(self, x, y, **kwargs):
         from .plotly_plots import BarPlot
 
-        fig = BarPlot(self.all_data, x, y, **kwargs)
+        fig = BarPlot(self.data, x, y, **kwargs)
 
         fig.layer = self
-        fig.ids = self.all_ids
+        fig.ids = self.ids
 
         return fig
 
@@ -167,10 +167,10 @@ class Plotting2dMixin:
     def histogram(self, x, **kwargs):
         from .plotly_plots import Histogram
 
-        fig = Histogram(self.all_data, x, **kwargs)
+        fig = Histogram(self.data, x, **kwargs)
 
         fig.layer = self
-        fig.ids = self.all_ids
+        fig.ids = self.ids
 
         return fig
 

--- a/drilldown/plotter.py
+++ b/drilldown/plotter.py
@@ -174,7 +174,6 @@ class DrillDownPlotter(Plotter):
         layer._image_array_names = intervals.image_var_names
 
         # enable decoding of hole IDs and categorical arrays
-        layer.code_to_hole_id_map = intervals.code_to_hole_id_map
         layer.code_to_cat_map = intervals.code_to_cat_map
 
         # handle categorical color maps
@@ -236,7 +235,6 @@ class DrillDownPlotter(Plotter):
         layer._image_array_names = points.image_var_names
 
         # enable decoding of hole IDs and categorical arrays
-        layer.code_to_hole_id_map = points.code_to_hole_id_map
         layer.code_to_cat_map = points.code_to_cat_map
 
         # handle categorical color maps

--- a/drilldown/plotter.py
+++ b/drilldown/plotter.py
@@ -1,39 +1,16 @@
 from vtk import (
-    vtkDataSetMapper,
-    vtkExtractSelection,
-    vtkSelectionNode,
-    vtkSelection,
     vtkPicker,
     vtkPropPicker,
-    vtkCellPicker,
-    vtkPointPicker,
-    vtkCellLocator,
-    vtkPointLocator,
-    vtkHardwareSelector,
-    vtkDataObject,
-    vtkCoordinate,
     vtkMapper,
 )
-import vtk.util.numpy_support as vtknumpy
-import pyvista as pv
 from pyvista import Plotter
-
-# from pyvista._vtk import vtkMapper
-
-import numpy as np
-import pandas as pd
-from IPython.display import IFrame
-import panel as pn
-from matplotlib import pyplot as plt
-from matplotlib.colors import ListedColormap
-from functools import partial
-
 from pyvista.trame.jupyter import show_trame
-from .drill_log import DrillLog
-from .utils import convert_to_numpy_array
+
+from IPython.display import IFrame
+
 from .image.image_mixin import ImageMixin
 from .plot.plotting_mixin import Plotting2dMixin
-from .layer.layer import DataLayer
+from .layer.layer import IntervalDataLayer, PointDataLayer
 
 
 def is_numeric_tuple(tup):
@@ -62,188 +39,47 @@ class DrillDownPlotter(Plotter, Plotting2dMixin, ImageMixin):
         self.enable_trackball_style()
         vtkMapper.SetResolveCoincidentTopologyToPolygonOffset()
 
-        self.layers = {}
+        self.layers = []
+
+        # track datasets
         self.collars = None
         self.surveys = None
-        self.datasets = {}
-        self.intervals = {}
-        self.points = {}
+        self.intervals = []
+        self.points = []
 
-        self._meshes = {}
-        self.mesh_names = []
-        self.interval_actors = {}
-        self.point_actors = {}
-        self.collar_actors = {}
+        # track collar and survey actors, in absence of layer classes
+        self.collar_actor = None
         self.survey_actor = None
-        self.interval_actor_names = []
-        self.point_actor_names = []
-
-        self._cmaps = plt.colormaps()
-
-        self.cells_per_interval = {}
-        self.n_intervals = {}
-        self.n_points = {}
-
-        self.categorical_vars = {}
-        self.continuous_vars = {}
-        self.all_vars = {}
-
-        self.interval_vars = {}
-        self.categorical_interval_vars = []
-        self.continuous_interval_vars = []
-        self.point_vars = {}
-        self.categorical_point_vars = []
-        self.continuous_point_vars = []
-
-        self.code_to_hole_id_map = {}
-        self.hole_id_to_code_map = {}
-        self.code_to_cat_map = {}
-        self.cat_to_code_map = {}
-        self.code_to_color_map = {}
-        self.cat_to_color_map = {}
-        self.matplotlib_formatted_color_maps = {}
 
         self._show_collar_labels = True
 
-        self._visibility = {}
-        self._opacity = {}
-
-        self._active_var = {}
-        self.prev_active_var = {}
-        self._cmap = {}
-        self.prev_continuous_cmap = {}
-        self._clim = {}
-
-        self.point_size = {}
-
-        # filter attributes
-        self.filter_opacity = {}
-        self.filter_opacity_factor = {}
-        self._data_filter = None
-        self._interval_filter = None
-        self._interval_cells_filter = None
-        self._point_filter = None
-
-        self.filtered_mesh = None
-        self.interval_filter_actor = None
-        self.point_filter_actor = None
-        self.filter_actor = None
-        self.interval_filter_actor_name = None
-        self.point_filter_actor_name = None
-        self.filter_actor_name = None
-
-        self._filtered_cells = []
-        self._filtered_points = []
-        self._filtered_intervals = []
-
-        # selection attributes
-        self.accelerated_selection = {}
-        self.selection_color = {}
-        self.selection_mesh = None
-        self.interval_selection_actor = None
-        self.point_selection_actor = None
-        self.selection_actor = None
-        self.interval_selection_actor_name = None
-        self.point_selection_actor_name = None
-        self.selection_actor_name = None
-
-        self._picked_cell = None
-        self._picked_point = None
-        self._selected_cells = []
-        self._selected_points = []
-        self._selected_intervals = []
-
+        # pickers for pIcKiNg
         self.actor_picker = vtkPropPicker()
         self.actors_to_make_not_pickable_picker = vtkPicker()
 
-        self.pickers = {}  # multiple to enable selective hardware acceleration
-
         # track clicks
-        self.track_click_position(side="left", callback=self._make_selection)
+        self.track_click_position(side="left", callback=self._pick)
         self.track_click_position(side="left", callback=self._reset_data, double=True)
 
-    def add_mesh(
-        self,
-        mesh,
-        name=None,
-        opacity=1,
-        pickable=False,
-        filter_opacity=0.1,
-        selection_color="magenta",
-        accelerated_selection=False,
-        as_filter=False,
-        as_selection=False,
-        *args,
-        **kwargs,
-    ):
-        """Add any PyVista mesh/VTK dataset that PyVista can wrap to the scene.
+    def add_collars(self, collars, show_labels=True, opacity=1, *args, **kwargs):
+        from .holes import Collars
 
-        Parameters
-        ----------
-        mesh : pyvista.DataSet or pyvista.MultiBlock or vtk.vtkAlgorithm
-            Any PyVista or VTK mesh is supported. Also, any dataset
-            that pyvista.wrap() can handle including NumPy arrays of XYZ points.
-            Plotting also supports VTK algorithm objects (vtk.vtkAlgorithm
-            and vtk.vtkAlgorithmOutput). When passing an algorithm, the
-            rendering pipeline will be connected to the passed algorithm
-            to dynamically update the scene.
+        if not isinstance(collars, Collars):
+            raise TypeError("collars must be a DrillDown.Collars object.")
 
-        name : str, optional
-            Name assigned to mesh
+        self.collars = collars
+        name = "collars"
+        if collars.mesh is None:
+            collars.make_mesh()
 
-        Returns
-        -------
-        pyvista.plotting.actor.Actor
-            Actor of the mesh.
-
-        """
-
-        self._meshes[name] = mesh
-        if (as_filter == False) and (as_selection == False):
-            self.mesh_names.append(name)
-            self.filter_opacity[name] = filter_opacity
-            self.filter_opacity_factor[name] = filter_opacity
-
-        actor = super(DrillDownPlotter, self).add_mesh(
-            mesh,
-            name=name,
-            pickable=pickable,
-            show_scalar_bar=False,
-            opacity=1,
-            *args,
-            **kwargs,
-        )
-
-        if pickable == True:
-            self._make_selectable(actor, selection_color, accelerated_selection)
-
-        self.opacity = (name, opacity)
-
-        return actor
-
-    def add_collars_mesh(
-        self,
-        mesh,
-        name="collars",
-        opacity=1,
-        show_labels=True,
-        selectable=True,
-        selection_color="magenta",
-        filter_opacity=0.1,
-        accelerated_selection=False,
-        *args,
-        **kwargs,
-    ):
+        mesh = collars.mesh
         actor = self.add_mesh(
             mesh,
             name,
             opacity=opacity,
             render_points_as_spheres=True,
             point_size=15,
-            pickable=selectable,
-            filter_opacity=filter_opacity,
-            selection_color=selection_color,
-            accelerated_selection=accelerated_selection,
+            pickable=False,
             *args,
             **kwargs,
         )
@@ -260,261 +96,21 @@ class DrillDownPlotter(Plotter, Plotting2dMixin, ImageMixin):
         else:
             return actor
 
-    def add_surveys_mesh(self, mesh, name="surveys", opacity=1, *args, **kwargs):
-        actor = self.add_mesh(mesh, name, opacity=opacity, *args, **kwargs)
-        self.survey_actor = actor
-        return actor
-
-    def _add_hole_data_mesh(
-        self,
-        mesh,
-        name=None,
-        opacity=1,
-        categorical_vars=[],
-        continuous_vars=[],
-        selectable=True,
-        active_var=None,
-        cmap=None,
-        clim=None,
-        selection_color="magenta",
-        filter_opacity=0.1,
-        accelerated_selection=False,
-        nan_opacity=1,
-        *args,
-        **kwargs,
-    ):
-        if active_var is None:  # default to first variable
-            self._active_var[name] = self.all_vars[name][0]
-
-        else:
-            self._active_var[name] = active_var
-
-        if cmap is None:
-            cmap = "Blues"
-        self.cmap[name] = cmap
-
-        if clim is None:
-            if name in self.interval_actor_names + self.point_actor_names:
-                if name in self.interval_actor_names:
-                    array = mesh.cell_data[self.active_var[name]]
-                else:
-                    array = mesh.point_data[self.active_var[name]]
-                min, max = np.nanmin(array), np.nanmax(array)
-                clim = (min, max)
-
-        self._clim[name] = clim
-
-        self.nan_opacity = nan_opacity
-
-        actor = self.add_mesh(
-            mesh,
-            name,
-            opacity=opacity,
-            pickable=selectable,
-            filter_opacity=filter_opacity,
-            selection_color=selection_color,
-            accelerated_selection=accelerated_selection,
-            *args,
-            **kwargs,
-        )
-
-        self.layers[name] = DataLayer(
-            name,
-            mesh,
-            actor,
-            self,
-            opacity=opacity,
-            pickable=selectable,
-            active_var=active_var,
-            cmap=cmap,
-            clim=clim,
-        )
-
-        if active_var is None:  # default to first variable
-            self.active_var = (name, self.all_vars[name][0])
-        else:
-            self.active_var = (name, active_var)
-        self.cmap = (name, cmap)
-        if clim is None:
-            self.reset_clim(name, active_var)
-        else:
-            self.clim = (name, clim)
-
-        return actor
-
-    def add_intervals_mesh(
-        self,
-        mesh,
-        name=None,
-        opacity=1,
-        categorical_vars=[],
-        continuous_vars=[],
-        selectable=True,
-        radius=1.5,
-        n_sides=20,
-        capping=False,
-        active_var=None,
-        cmap=None,
-        clim=None,
-        selection_color="magenta",
-        filter_opacity=0.1,
-        accelerated_selection=False,
-        nan_opacity=1,
-        *args,
-        **kwargs,
-    ):
-        """Add a PyVista mesh/VTK dataset representing drillhole intervals to the scene.
-
-        Parameters
-        ----------
-        mesh : pyvista.PolyData or vtk.vtkPolyData
-            PyVista mesh/VTK dataset representing drillhole intervals.
-        selectable : bool, optional
-            Make the mesh available for selection. By default True
-        radius : float, optional
-            Minimum hole radius (minimum because the radius may vary). By default 1.5
-        n_sides : int, optional
-            Number of sides for the hole. By default 20
-        capping : bool, optional
-            Enable or disable capping of each hole interval. By default True
-        active_var : str, optional
-            Variable corresponding to default scalar array used to color hole intervals. By default None.
-        cmap : str, optional
-            Matplotlib colormap used to color interval data. By default "Blues"
-        clim : tuple, optional
-            Minimum and maximum value between which colormap is applied. By default None
-        selection_color : ColorLike, optional
-            Color used to color the selection object. By default "#000000"
-        accelerated_selection : bool, optional
-            When True, accelerates selection using two methods:
-            1.) adding a vtkCellLocator object to the vtkCellPicker object
-            2.) using hardware selection.
-            The latter is less accurate than normal picking. Thus, activating accelerated selection
-            increases selection speed but decreases selection accuracy. By default False
-        """
-        self.interval_actor_names.append(name)
-        self.n_intervals[name] = mesh.n_lines
-        if capping == True:
-            self.cells_per_interval[name] = n_sides + 2
-        else:
-            self.cells_per_interval[name] = n_sides
-
-        mesh = mesh.tube(radius=radius, n_sides=n_sides, capping=capping)
-        actor = self._add_hole_data_mesh(
-            mesh,
-            name,
-            opacity=opacity,
-            categorical_vars=categorical_vars,
-            continuous_vars=continuous_vars,
-            selectable=selectable,
-            active_var=active_var,
-            cmap=cmap,
-            clim=clim,
-            filter_opacity=filter_opacity,
-            selection_color=selection_color,
-            accelerated_selection=accelerated_selection,
-            nan_opacity=nan_opacity,
-            *args,
-            **kwargs,
-        )
-        self.interval_actors[name] = actor
-
-        return actor
-
-    def add_points_mesh(
-        self,
-        mesh,
-        name=None,
-        opacity=1,
-        categorical_vars=[],
-        continuous_vars=[],
-        point_size=10,
-        selectable=True,
-        active_var=None,
-        cmap=None,
-        clim=None,
-        selection_color="magenta",
-        filter_opacity=0.1,
-        accelerated_selection=False,
-        nan_opacity=1,
-        *args,
-        **kwargs,
-    ):
-        self.point_actor_names.append(name)
-        self.categorical_point_vars += categorical_vars
-        self.continuous_point_vars += continuous_vars
-        self.n_points[name] = mesh.n_points
-
-        actor = self._add_hole_data_mesh(
-            mesh,
-            name,
-            opacity=opacity,
-            categorical_vars=categorical_vars,
-            continuous_vars=continuous_vars,
-            point_size=point_size,
-            render_points_as_spheres=True,
-            selectable=selectable,
-            active_var=active_var,
-            cmap=cmap,
-            clim=clim,
-            filter_opacity=filter_opacity,
-            selection_color=selection_color,
-            accelerated_selection=accelerated_selection,
-            nan_opacity=nan_opacity,
-            *args,
-            **kwargs,
-        )
-        self.point_actors[name] = actor
-
-        return actor
-
-    def add_collars(self, collars, opacity=1):
-        from .holes import Collars
-
-        if not isinstance(collars, Collars):
-            raise TypeError("collars must be a DrillDown.Collars object.")
-
-        self.collars = collars
-        name = "collars"
-        if collars.mesh is None:
-            collars.make_mesh()
-
-        collars_actor = self.add_collars_mesh(collars.mesh, name, opacity=opacity)
-
-        return collars_actor
-
-    def add_surveys(self, surveys, opacity=1):
+    def add_surveys(self, surveys, opacity=1, *args, **kwargs):
         from .holes import Surveys
 
         if not isinstance(surveys, Surveys):
             raise TypeError("surveys must be a DrillDown.Surveys object.")
 
         self.surveys = surveys
-        name = "surveys"
         if surveys.mesh is None:
             surveys.make_mesh()
 
-        surveys_actor = self.add_surveys_mesh(surveys.mesh, name, opacity=opacity)
+        mesh = surveys.mesh
+        actor = self.add_mesh(mesh, "surveys", opacity=opacity, *args, **kwargs)
+        self.survey_actor = actor
 
-        return surveys_actor
-
-    def _add_hole_data(self, data, name):
-        data._construct_categorical_cmap()
-
-        self.datasets[name] = data
-        self.continuous_vars[name] = data.continuous_vars
-        self.categorical_vars[name] = data.categorical_vars
-        self.all_vars[name] = data.continuous_vars + data.categorical_vars
-
-        self.hole_id_to_code_map[name] = data.hole_id_to_code_map
-        self.code_to_hole_id_map[name] = data.code_to_hole_id_map
-        self.cat_to_code_map[name] = data.cat_to_code_map
-        self.code_to_cat_map[name] = data.code_to_cat_map
-        self.code_to_color_map[name] = data.code_to_color_map
-        self.cat_to_color_map[name] = data.cat_to_color_map
-        self.matplotlib_formatted_color_maps[
-            name
-        ] = data.matplotlib_formatted_color_maps
+        return actor
 
     def add_intervals(
         self,
@@ -524,14 +120,12 @@ class DrillDownPlotter(Plotter, Plotting2dMixin, ImageMixin):
         selectable=True,
         radius=1.5,
         n_sides=20,
-        capping=False,
         active_var=None,
         cmap=None,
         clim=None,
         selection_color="magenta",
         filter_opacity=0.1,
         accelerated_selection=False,
-        nan_opacity=1,
         *args,
         **kwargs,
     ):
@@ -540,35 +134,44 @@ class DrillDownPlotter(Plotter, Plotting2dMixin, ImageMixin):
         if not isinstance(intervals, Intervals):
             raise TypeError("intervals must be a DrillDown.Intervals object.")
 
-        self.intervals[name] = intervals
-        self.interval_vars[name] = intervals.vars_all
-        self.categorical_interval_vars += intervals.categorical_vars
-        self.continuous_interval_vars += intervals.continuous_vars
-        self._add_hole_data(intervals, name)
-
         if intervals.mesh is None:
             intervals.make_mesh()
 
-        intervals_actor = self.add_intervals_mesh(
-            intervals.mesh,
+        mesh = intervals.mesh
+        mesh = mesh.tube(radius=radius, n_sides=n_sides, capping=False)
+
+        actor = self.add_mesh(
+            mesh,
             name,
             opacity=opacity,
-            selectable=selectable,
-            radius=radius,
-            n_sides=n_sides,
-            capping=capping,
-            active_var=active_var,
+            pickable=selectable,
+            scalars=active_var,
             cmap=cmap,
             clim=clim,
-            selection_color=selection_color,
-            filter_opacity=filter_opacity,
-            accelerated_selection=accelerated_selection,
-            nan_opacity=nan_opacity,
             *args,
             **kwargs,
         )
 
-        return intervals_actor
+        layer = IntervalDataLayer(name, mesh, actor, self, n_sides=n_sides)
+
+        # handle categorical vs continuous arrays
+        layer._categorical_array_names = intervals.categorical_vars
+        layer._continuous_array_names = intervals.continuous_vars
+
+        # enable decoding of hole IDs and categorical arrays
+        layer.code_to_hole_id_map = intervals.code_to_hole_id_map
+        layer.code_to_cat_map = intervals.code_to_cat_map
+
+        # handle categorical color maps
+        intervals._construct_categorical_cmap()
+        layer.cat_to_color_map = intervals.cat_to_color_map
+        layer.matplotlib_formatted_color_maps = (
+            intervals.matplotlib_formatted_color_maps
+        )
+
+        self.layers.append(layer)
+
+        return actor
 
     def add_points(
         self,
@@ -583,7 +186,6 @@ class DrillDownPlotter(Plotter, Plotting2dMixin, ImageMixin):
         selection_color="magenta",
         filter_opacity=0.1,
         accelerated_selection=False,
-        nan_opacity=1,
         *args,
         **kwargs,
     ):
@@ -591,140 +193,45 @@ class DrillDownPlotter(Plotter, Plotting2dMixin, ImageMixin):
 
         if not isinstance(points, Points):
             raise TypeError("points must be a DrillDown.Points object.")
-        self.points[name] = points
-        self.point_vars[name] = points.vars_all
-        self.categorical_point_vars += points.categorical_vars
-        self.continuous_point_vars += points.continuous_vars
-        self.point_size[name] = point_size
-        self._add_hole_data(points, name)
 
         if points.mesh is None:
             points.make_mesh()
 
-        points_actor = self.add_points_mesh(
-            points.mesh,
+        mesh = points.mesh
+        actor = self.add_mesh(
+            mesh,
             name,
             opacity=opacity,
+            pickable=selectable,
             point_size=point_size,
-            selectable=selectable,
-            active_var=active_var,
+            render_points_as_spheres=True,
+            scalars=active_var,
             cmap=cmap,
             clim=clim,
-            selection_color=selection_color,
-            filter_opacity=filter_opacity,
-            accelerated_selection=accelerated_selection,
-            nan_opacity=nan_opacity,
             *args,
             **kwargs,
         )
 
-        return points_actor
+        layer = PointDataLayer(name, mesh, actor, self)
 
-    def add_holes(self, holes, name=None, *args, **kwargs):
-        # add color-category and code-category maps
-        self.code_to_hole_id_map = holes.code_to_hole_id_map
-        self.hole_id_to_code_map = holes.hole_id_to_code_map
-        self.code_to_cat_map = holes.code_to_cat_map
-        self.cat_to_code_map = holes.cat_to_code_map
-        self.code_to_color_map = holes.code_to_color_map
-        self.cat_to_color_map = holes.cat_to_color_map
-        self.matplotlib_formatted_color_maps = holes.matplotlib_formatted_color_maps
+        # handle categorical vs continuous arrays
+        layer._categorical_array_names = points.categorical_vars
+        layer._continuous_array_names = points.continuous_vars
 
-        # make and add collars mesh
-        collars_mesh = holes.make_collars_mesh()
-        self.add_collars_mesh(collars_mesh)
+        # enable decoding of hole IDs and categorical arrays
+        layer.code_to_hole_id_map = points.code_to_hole_id_map
+        layer.code_to_cat_map = points.code_to_cat_map
 
-        # make and add surveys mesh
-        surveys_mesh = holes.make_surveys_mesh()
-        self.add_surveys_mesh(surveys_mesh)
+        # handle categorical color maps
+        points._construct_categorical_cmap()
+        layer.cat_to_color_map = points.cat_to_color_map
+        layer.matplotlib_formatted_color_maps = points.matplotlib_formatted_color_maps
 
-        # make and add intervals mesh(es)
-        for name in holes.intervals.keys():
-            intervals_mesh = holes.make_intervals_mesh(name)
-            self.add_intervals_mesh(
-                intervals_mesh,
-                name,
-                holes.categorical_interval_vars,
-                holes.continuous_interval_vars,
-            )
+        self.layers.append(layer)
 
-        # make and add points mesh(es)
-        for name in holes.points.keys():
-            points_mesh = holes.make_points_mesh(name)
-            self.add_points_mesh(
-                points_mesh,
-                name,
-                holes.categorical_point_vars,
-                holes.continuous_point_vars,
-            )
+        return actor
 
-    @property
-    def cmaps(self):
-        return self._cmaps
-
-    def _make_selectable(
-        self,
-        actor,
-        selection_color="magenta",
-        accelerated_selection=False,
-    ):
-        name = actor.name
-        self.selection_color[name] = selection_color
-        self.accelerated_selection[name] = accelerated_selection
-
-        if (name in self.interval_actor_names) or (
-            name == self.interval_filter_actor_name
-        ):
-            picker = self._make_intervals_selectable(actor, accelerated_selection)
-            self.pickers[name] = picker
-
-        elif (name in self.point_actor_names) or (name == self.point_filter_actor_name):
-            picker = self._make_points_selectable(actor, accelerated_selection)
-            self.pickers[name] = picker
-
-        # elif name == "collars":
-        #     picker = self._make_points_selectable(actor, accelerated_selection)
-        #     self.pickers[name] = picker
-
-    def _make_intervals_selectable(self, actor, accelerated_selection=False):
-        # set cell picker
-        cell_picker = vtkCellPicker()
-        cell_picker.SetTolerance(0.0005)
-
-        if accelerated_selection == True:
-            # add locator for acceleration
-            cell_locator = vtkCellLocator()
-            cell_locator.SetDataSet(actor.mapper.dataset)
-            cell_locator.BuildLocator()
-            cell_picker.AddLocator(cell_locator)
-
-            # use hardware selection for acceleration
-            hw_selector = vtkHardwareSelector()
-            hw_selector.SetFieldAssociation(vtkDataObject.FIELD_ASSOCIATION_CELLS)
-            hw_selector.SetRenderer(self.renderer)
-
-        return cell_picker
-
-    def _make_points_selectable(self, actor, accelerated_selection=False):
-        # set point picker
-        point_picker = vtkPointPicker()
-        point_picker.SetTolerance(0.005)
-
-        if accelerated_selection == True:
-            # add locator for acceleration
-            point_locator = vtkPointLocator()
-            point_locator.SetDataSet(actor.mapper.dataset)
-            point_locator.BuildLocator()
-            point_picker.AddLocator(point_locator)
-
-            # use hardware selection for acceleration
-            hw_selector = vtkHardwareSelector()
-            hw_selector.SetFieldAssociation(vtkDataObject.FIELD_ASSOCIATION_POINTS)
-            hw_selector.SetRenderer(self.renderer)
-
-        return point_picker
-
-    def _make_selection(self, *args):
+    def _pick(self, *args):
         pos = self.click_position + (0,)
         actor_picker = self.actor_picker
         actor_picker.Pick(pos[0], pos[1], pos[2], self.renderer)
@@ -744,1247 +251,19 @@ class DrillDownPlotter(Plotter, Plotting2dMixin, ImageMixin):
                 prev_pickable.append(actor.GetPickable())
                 actor.SetPickable(False)
 
-            name = picked_actor.name
+            # make selection
+            layer = self.layers[0]
+            layer._make_selection_by_pick(pos, picked_actor)
+            layer._update_selection_object()
 
-            if name == self.filter_actor_name:
-                selection_on_filter = True
-                name = name.split(" ")[0]
-
-            else:
-                selection_on_filter = False
-
-            if name in self.interval_actor_names:
-                self._reset_point_selection()
-                self._make_intervals_selection(
-                    name, pos, selection_on_filter=selection_on_filter
-                )
-                self._update_data_selection_object(
-                    name, selection_on_filter=selection_on_filter
-                )
-
-            elif name in self.point_actor_names:
-                self._reset_interval_selection()
-                self._make_points_selection(
-                    name, pos, selection_on_filter=selection_on_filter
-                )
-                self._update_data_selection_object(
-                    name, selection_on_filter=selection_on_filter
-                )
-
+            # restore previous pickable state
             for actor, val in zip(actors_to_make_not_pickable, prev_pickable):
                 actor.SetPickable(val)
 
-            # elif name == "collars":
-            #     self._make_collars_selection(pos)
-            #     self._update_collar_selection_object(name)
-
-    # def _make_collars_selection(self, pos):
-    #     self.actors["intervals"].SetPickable(False)
-    #     point_picker = self.pickers["collars"]
-    #     point_picker.Pick(pos[0], pos[1], pos[2], self.renderer)
-    #     picked_point = point_picker.GetPointId()
-    #     if picked_point is not None:
-    #         if picked_point == -1:
-    #             return
-
-    #         self._make_single_point_selection("collars", picked_point)
-    #         self._picked_point = picked_point
-    #     self.actors["intervals"].SetPickable(True)
-
-    def _make_intervals_selection(self, name, pos, selection_on_filter=False):
-        if selection_on_filter == True:
-            cell_picker = self.pickers[name + " filter"]
-        else:
-            cell_picker = self.pickers[name]
-
-        cell_picker.Pick(pos[0], pos[1], pos[2], self.renderer)
-
-        picked_cell = cell_picker.GetCellId()
-        # if name == self.interval_filter_actor_name:
-        #     name = name.split(" ")[0]
-
-        if picked_cell is not None:
-            # if cell_picker.GetActor().name in self.point_actor_names:
-            #     return
-
-            shift_pressed = self.iren.interactor.GetShiftKey()
-            ctrl_pressed = self.iren.interactor.GetControlKey()
-            if shift_pressed == True:
-                self._make_continuous_multi_interval_selection(
-                    name, picked_cell, selection_on_filter=selection_on_filter
-                )
-
-            elif ctrl_pressed == True:
-                self._make_discontinuous_multi_interval_selection(
-                    name, picked_cell, selection_on_filter=selection_on_filter
-                )
-
-            else:
-                self._make_single_interval_selection(
-                    name, picked_cell, selection_on_filter=selection_on_filter
-                )
-
-            if selection_on_filter == True:
-                picked_cell = self._filtered_cells[picked_cell]
-
-            self._picked_cell = picked_cell
-
-    def _make_points_selection(self, name, pos, selection_on_filter=False):
-        if selection_on_filter == True:
-            point_picker = self.pickers[name + " filter"]
-        else:
-            point_picker = self.pickers[name]
-
-        point_picker.Pick(pos[0], pos[1], pos[2], self.renderer)
-        picked_point = point_picker.GetPointId()
-        if picked_point is not None:
-            if picked_point == -1:
-                return
-
-            shift_pressed = self.iren.interactor.GetShiftKey()
-            ctrl_pressed = self.iren.interactor.GetControlKey()
-            if shift_pressed == True:
-                self._make_continuous_multi_point_selection(
-                    name, picked_point, selection_on_filter=selection_on_filter
-                )
-
-            elif ctrl_pressed == True:
-                self._make_discontinuous_multi_point_selection(
-                    name, picked_point, selection_on_filter=selection_on_filter
-                )
-
-            else:
-                self._make_single_point_selection(
-                    name, picked_point, selection_on_filter=selection_on_filter
-                )
-
-            if selection_on_filter == True:
-                picked_point = self._filtered_points[picked_point]
-
-            self._picked_point = picked_point
-
-    def _make_single_interval_selection(
-        self, name, picked_cell, selection_on_filter=False
-    ):
-        cells_per_interval = self.cells_per_interval[name]
-        selected_interval = int(np.floor(picked_cell / cells_per_interval))
-        selected_cells = np.arange(
-            selected_interval * cells_per_interval,
-            (selected_interval + 1) * cells_per_interval,
-        ).tolist()
-
-        if selection_on_filter == True:
-            selected_interval = self._filtered_intervals[selected_interval]
-            selected_cells = list(self._filtered_cells[selected_cells])
-
-        self._selected_intervals = [selected_interval]
-        self._selected_cells = selected_cells
-
-    def _make_single_point_selection(
-        self, name, picked_point, selection_on_filter=False
-    ):
-        if selection_on_filter == True:
-            picked_point = self._filtered_points[picked_point]
-
-        self._selected_points = [picked_point]
-
-    def _make_discontinuous_multi_interval_selection(
-        self, name, picked_cell, selection_on_filter=False
-    ):
-        cells_per_interval = self.cells_per_interval[name]
-        selected_interval = int(np.floor(picked_cell / cells_per_interval))
-        selected_cells = np.arange(
-            selected_interval * cells_per_interval,
-            (selected_interval + 1) * cells_per_interval,
-        ).tolist()
-
-        if selection_on_filter == True:
-            selected_interval = self._filtered_intervals[selected_interval]
-            selected_cells = list(self._filtered_cells[selected_cells])
-
-        self._selected_intervals += [selected_interval]
-        self._selected_cells += selected_cells
-
-    def _make_discontinuous_multi_point_selection(
-        self, name, picked_point, selection_on_filter=False
-    ):
-        pass
-
-    def _make_continuous_multi_interval_selection(
-        self, name, picked_cell, selection_on_filter=False
-    ):
-        cells_per_interval = self.cells_per_interval[name]
-        if selection_on_filter == True:
-            prev_picked_cell = np.where(self._filtered_cells == self._picked_cell)[0][0]
-            prev_selected_intervals = np.where(
-                np.isin(self._filtered_intervals, self._selected_intervals[:-1])
-            )[0].tolist()
-            prev_selected_intervals += np.where(
-                np.isin(self._filtered_intervals, self._selected_intervals[-1])
-            )[
-                0
-            ].tolist()  #  needed as np.isin or np.where seems to sort the output and the resulting first interval should be last
-
-        else:
-            prev_picked_cell = self._picked_cell
-            prev_selected_intervals = self._selected_intervals
-
-        if prev_picked_cell is not None:
-            if prev_picked_cell < picked_cell:  # normal direction (down the hole)
-                selected_intervals = np.arange(
-                    prev_selected_intervals[-1] + 1,
-                    int(np.floor(picked_cell / cells_per_interval)) + 1,
-                ).tolist()
-                selected_cells = np.arange(
-                    (selected_intervals[0]) * cells_per_interval,
-                    (selected_intervals[-1] + 1) * cells_per_interval,
-                ).tolist()
-
-                if selection_on_filter == True:
-                    selected_intervals = list(
-                        self._filtered_intervals[selected_intervals]
-                    )
-                    selected_cells = list(self._filtered_cells[selected_cells])
-
-                self._selected_intervals += selected_intervals
-                self._selected_cells += selected_cells
-
-            else:  # reverse direction (up the hole)
-                selected_intervals = np.arange(
-                    int(np.floor(picked_cell / cells_per_interval)),
-                    prev_selected_intervals[-1],
-                ).tolist()
-                selected_cells = np.arange(
-                    (selected_intervals[0] * cells_per_interval),
-                    (selected_intervals[-1] + 1) * cells_per_interval,
-                ).tolist()
-
-                if selection_on_filter == True:
-                    selected_intervals = list(
-                        self._filtered_intervals[selected_intervals]
-                    )
-                    selected_cells = list(self._filtered_cells[selected_cells])
-
-                self._selected_intervals = selected_intervals + self._selected_intervals
-                self._selected_cells = selected_cells + self._selected_cells
-
-    def _make_continuous_multi_point_selection(
-        self, name, picked_point, selection_on_filter
-    ):
-        pass  # not trivial as cell IDs are not inherently sequential along hole
-
-    # def _reset_collar_selection(self):
-    #     self._picked_point = None
-    #     self._selected_points = []
-    #     self.remove_actor(self.selection_actor)
-    #     self.selection_actor = None
-    #     self.selection_actor_name = None
-    #     self.point_selection_actor = None
-
-    def _reset_interval_selection(self):
-        self._picked_cell = None
-        self._selected_intervals = []
-        self._selected_cells = []
-
-        self.remove_actor(self.selection_actor)
-        self.selection_actor = None
-        self.selection_mesh = None
-        self.selection_actor_name = None
-        self.interval_selection_actor = None
-        self.interval_selection_actor_name = None
-
-    def _reset_point_selection(self):
-        self._picked_point = None
-        self._selected_points = []
-
-        self.remove_actor(self.selection_actor)
-        self.selection_actor = None
-        self.selection_mesh = None
-        self.selection_actor_name = None
-        self.point_selection_actor = None
-        self.point_selection_actor_name = None
-
-    def _reset_data_selection(self, *args):
-        pos = self.click_position + (0,)
-        actor_picker = self.actor_picker
-        actor_picker.Pick(pos[0], pos[1], pos[2], self.renderer)
-        picked_actor = actor_picker.GetActor()
-        if picked_actor is not None:
-            name = picked_actor.name
-            if name in self.interval_actor_names:
-                self._reset_point_selection()
-            elif name in self.point_actor_names:
-                self._reset_interval_selection()
-            else:
-                return
-        else:
-            self._reset_interval_selection()
-            self._reset_point_selection()
-        # self._reset_collar_selection()
-
-    def _reset_interval_filter(self):
-        self._picked_cell = None
-        self._filtered_intervals = []
-        self._filtered_cells = []
-
-        for name in self.interval_actor_names + self.point_actor_names:
-            self.actors[name].prop.opacity = 1
-
-        if self.interval_filter_actor is not None:
-            self.remove_actor(self.interval_filter_actor)
-            self.actors[
-                self.interval_filter_actor_name.replace(" filter", "")
-            ].SetPickable(True)
-
-        self.filter_actor = None
-        self.filter_actor_name = None
-        self.interval_filter_actor = None
-        self.interval_filter_actor_name = None
-
-    def _reset_point_filter(self):
-        self._picked_point = None
-        self._filtered_points = []
-
-        for name in self.interval_actor_names + self.point_actor_names:
-            self.actors[name].prop.opacity = 1
-
-        if self.point_filter_actor is not None:
-            self.remove_actor(self.selection_actor)
-            self.actors[
-                self.point_filter_actor_name.replace(" filter", "")
-            ].SetPickable(True)
-
-        self.filter_actor = None
-        self.filter_actor_name = None
-        self.point_filter_actor = None
-        self.interval_filter_actor_name = None
-
-    def _reset_data_filter(self, *args):
-        pos = self.click_position + (0,)
-        actor_picker = self.actor_picker
-        actor_picker.Pick(pos[0], pos[1], pos[2], self.renderer)
-        picked_actor = actor_picker.GetActor()
-        if picked_actor is not None:
-            name = picked_actor.name
-            if name in self.interval_actor_names:
-                self._reset_point_filter()
-            elif name in self.point_actor_names:
-                self._reset_interval_filter()
-            else:
-                return
-        else:
-            self._reset_interval_filter()
-            self._reset_point_filter()
-        # self._reset_collar_filter
-
     def _reset_data(self, *args):
-        if self.selection_actor is not None:
-            self._reset_data_selection()
-            return
-        else:
-            self._reset_data_filter()
-            return
-
-    # def
-    # def _update_collar_filter_object(self, name):
-    #     filtered_name = "collars filter"
-    #     mesh = self._meshes[name]
-    #     filtered_points = self._filtered_points
-    #     filtered_mesh = mesh.extract_points(filtered_points)
-    #     if (filtered_mesh.n_points!= 0) and (filtered_mesh.n_cells != 0):
-    #         self.filtered_mesh = filtered_mesh
-    #         filter_actor = self.add_mesh(
-    #             filtered_mesh,
-    #             filtered_name,
-    #             point_size=20,
-    #             render_points_as_spheres=True,
-    #             reset_camera=False,
-    #             pickable=True,
-    #         )
-    #     self.filter_actor = filter_actor
-    #     self.filtered_hole_ids = filtered_mesh["hole ID"]
-    #     return filter_actor
-
-    def _update_data_filter_object(self, name):
-        filtered_name = name + " filter"
-        self.filter_actor_name = filtered_name
-
-        if name in self.interval_actor_names:
-            self.interval_filter_actor_name = filtered_name
-            filter_actor = self._update_interval_filter_object(name)
-            self.interval_filter_actor = filter_actor
-
-        elif name in self.point_actor_names:
-            self.point_filter_actor_name = filtered_name
-            filter_actor = self._update_point_filter_object(name)
-            self.point_filter_actor = filter_actor
-
-        self.filter_actor = filter_actor
-
-        if filter_actor is not None:
-            filter_actor.mapper.SetRelativeCoincidentTopologyPolygonOffsetParameters(
-                0, -5
-            )
-
-        # update non-selected
-        self.actors[name].prop.opacity = self.filter_opacity[name]
-        self.actors[name].SetPickable(False)
-
-        # update selected holes
-        self._selected_hole_ids = [
-            self.code_to_hole_id_map[name][id]
-            for id in np.unique(self.filter_mesh["hole ID"])
-        ]
-        self.render()
-        pass
-
-    def _update_interval_filter_object(self, name):
-        filtered_name = name + " filter"
-
-        # update selected
-        mesh = self._meshes[name]
-        filtered_cells = self._filtered_cells
-        filter_mesh = mesh.extract_cells(filtered_cells)
-        if (filter_mesh.n_points != 0) and (filter_mesh.n_cells != 0):
-            self.filter_mesh = filter_mesh
-
-            filter_actor = self.add_mesh(
-                filter_mesh,
-                filtered_name,
-                scalars=self.active_var[name],
-                cmap=self.cmap[name],
-                clim=self.clim[name],
-                reset_camera=False,
-                pickable=True,
-                selection_color=self.selection_color[name],
-                accelerated_selection=self.accelerated_selection[name],
-                as_filter=True,
-            )
-            return filter_actor
-
-    def _update_point_filter_object(self, name):
-        filtered_name = name + " filter"
-
-        # update selected
-        mesh = self._meshes[name]
-        filtered_points = self._filtered_points
-        filter_mesh = mesh.extract_points(filtered_points)
-        if (filter_mesh.n_points != 0) and (filter_mesh.n_cells != 0):
-            self.filter_mesh = filter_mesh
-            filter_actor = self.add_mesh(
-                filter_mesh,
-                filtered_name,
-                point_size=10,
-                render_points_as_spheres=True,
-                scalars=self.active_var[name],
-                cmap=self.cmap[name],
-                clim=self.clim[name],
-                reset_camera=False,
-                pickable=True,
-                selection_color=self.selection_color[name],
-                accelerated_selection=self.accelerated_selection[name],
-                as_filter=True,
-            )
-            return filter_actor
-
-    # def _update_collar_selection_object(self, name):
-    #     selection_name = "collars selection"
-
-    #     mesh = self._meshes[name]
-    #     selected_points = self._selected_points
-    #     selection_mesh = mesh.extract_points(selected_points)
-    #     if (selection_mesh.n_points != 0) and (selection_mesh.n_cells != 0):
-    #         self.selection_mesh = selection_mesh
-    #         selection_actor = self.add_mesh(
-    #             selection_mesh,
-    #             selection_name,
-    #             point_size=20,
-    #             render_points_as_spheres=True,
-    #             color=self.selection_color[name],
-    #             reset_camera=False,
-    #             pickable=False,
-    #         )
-    #         self.selection_actor = selection_actor
-
-    #         self.selected_hole_ids = selection_mesh["hole ID"]
-    #         return selection_actor
-
-    def _update_data_selection_object(self, name, selection_on_filter=False):
-        selection_name = name + " selection"
-        self.selection_actor_name = selection_name
-
-        if name in self.interval_actor_names:
-            self.interval_selection_actor_name = selection_name
-            selection_actor = self._update_interval_selection_object(
-                name, selection_on_filter=selection_on_filter
-            )
-            self.interval_selection_actor = selection_actor
-
-        elif name in self.point_actor_names:
-            self.point_selection_actor_name = selection_name
-            selection_actor = self._update_point_selection_object(
-                name, selection_on_filter=selection_on_filter
-            )
-            self.point_selection_actor = selection_actor
-
-        else:
-            return
-
-        self.selection_actor = selection_actor
-
-        if selection_actor is not None:
-            selection_actor.mapper.SetRelativeCoincidentTopologyPolygonOffsetParameters(
-                0, -6
-            )
-
-            # update selected holes
-            self._selected_hole_ids = [
-                self.code_to_hole_id_map[name][id]
-                for id in np.unique(self.selection_mesh["hole ID"])
-            ]
-        self.render()
-
-    def _update_interval_selection_object(self, name, selection_on_filter=False):
-        selection_name = name + " selection"
-
-        # update selected
-        mesh = self._meshes[name]
-        selected_cells = self._selected_cells
-        selection_mesh = mesh.extract_cells(selected_cells)
-        if (selection_mesh.n_points != 0) and (selection_mesh.n_cells != 0):
-            self.selection_mesh = selection_mesh
-
-            selection_actor = self.add_mesh(
-                selection_mesh,
-                selection_name,
-                color=self.selection_color[name],
-                reset_camera=False,
-                pickable=False,
-                as_selection=True,
-            )
-            return selection_actor
-
-    def _update_point_selection_object(self, name, selection_on_filter=False):
-        selection_name = name + " selection"
-
-        # update selected
-        mesh = self._meshes[name]
-        selected_points = self._selected_points
-        selection_mesh = mesh.extract_points(selected_points)
-        if (selection_mesh.n_points != 0) and (selection_mesh.n_cells != 0):
-            self.selection_mesh = selection_mesh
-            selection_actor = self.add_mesh(
-                selection_mesh,
-                selection_name,
-                point_size=self.point_size[name] + 1,
-                render_points_as_spheres=True,
-                color=self.selection_color[name],
-                reset_camera=False,
-                pickable=False,
-                as_selection=True,
-            )
-            return selection_actor
-
-    @property
-    def active_var(self):
-        return self._active_var
-
-    @active_var.setter
-    def active_var(self, key_value_pair):
-        if isinstance(key_value_pair, tuple):
-            if len(key_value_pair) == 2:
-                name, active_var = key_value_pair
-            else:
-                raise ValueError(
-                    "Input must be a tuple of length 2, where the first element is the name of the dataset and the second element is the name of the active variable."
-                )
-        elif isinstance(key_value_pair, str):
-            if len(self.mesh_names) == 1:
-                active_var = key_value_pair
-                name = self.mesh_names[0]
-            else:
-                raise ValueError(
-                    "Multiple datasets are present. Please specify name of dataset."
-                )
-        else:
-            raise ValueError("Input must be a tuple or a str.")
-
-        if name not in self.all_vars.keys():
-            raise ValueError(
-                f"No dataset corresponding to {name} is present. Dataset names are {self.all_vars.keys()}."
-            )
-
-        if active_var not in self.all_vars[name]:
-            raise ValueError(f"{active_var} is not a valid variable for {name}.")
-        self._active_var[name] = active_var
-
-        actors = []
-        actor = self.actors.get(name, None)
-        actors.append(actor)
-        if actor is not None:
-            if (self.filter_actor is not None) and (
-                self.filter_actor_name == name + " filter"
-            ):
-                actors.append(self.filter_actor)
-        for actor in actors:
-            actor.mapper.dataset.set_active_scalars(active_var)
-
-        if active_var in self.categorical_vars[name]:
-            cmap = self.matplotlib_formatted_color_maps.get(active_var, None)
-            self.cmap = (name, cmap)
-            clim = list(self.code_to_cat_map[name][active_var].keys())[-1]
-            self.clim = (
-                name,
-                (0, clim),
-            )
-        elif active_var in self.continuous_vars[name]:
-            if self.prev_active_var.get(name, None) in self.categorical_vars[name]:
-                cmap = self.prev_continuous_cmap[name]
-                self.cmap = (name, cmap)
-
-            self.reset_clim(name, active_var)
-
-        self.prev_active_var[name] = active_var
-
-        self.render()
-
-    @property
-    def cmap(self):
-        return self._cmap
-
-    @cmap.setter
-    def cmap(self, key_value_pair):
-        if isinstance(key_value_pair, tuple):
-            if len(key_value_pair) == 2:
-                name, cmap = key_value_pair
-            else:
-                raise ValueError(
-                    "Input must be a tuple of length 2, where the first element is the name of the dataset and the second element is the colormap."
-                )
-        elif isinstance(key_value_pair, str):
-            if len(self.mesh_names) == 1:
-                cmap = key_value_pair
-                name = self.mesh_names[0]
-            else:
-                raise ValueError(
-                    "Multiple datasets are present. Please specify name of dataset."
-                )
-        else:
-            raise ValueError("Input must be a tuple or a str.")
-
-        self._cmap[name] = cmap
-
-        actors = []
-        actor = self.actors.get(name, None)
-        actors.append(actor)
-        if actor is not None:
-            if (self.filter_actor is not None) and (
-                self.filter_actor_name == name + " filter"
-            ):
-                actors.append(self.filter_actor)
-            for actor in actors:
-                if self.active_var[name] in self.continuous_vars[name]:
-                    actor.mapper.lookup_table.cmap = cmap
-                    self.prev_continuous_cmap[name] = cmap
-
-                else:
-                    cmap = self.matplotlib_formatted_color_maps[name].get(
-                        self.active_var[name], None
-                    )
-                    actor.mapper.lookup_table = pv.LookupTable(cmap)
-                actor.mapper.lookup_table.nan_color = "white"  # self.nan_opacity
-
-        self.render()
-
-    @property
-    def clim(self):
-        return self._clim
-
-    @clim.setter
-    def clim(self, key_value_pair):
-        if isinstance(key_value_pair, tuple):
-            if len(key_value_pair) == 2:
-                if isinstance(key_value_pair[0], str):
-                    name, clim = key_value_pair
-                elif is_numeric_tuple(key_value_pair):
-                    if len(self.mesh_names) == 1:
-                        clim = key_value_pair
-                        name = self.mesh_names[0]
-                    else:
-                        raise ValueError(
-                            "Multiple datasets are present. Please specify name of dataset."
-                        )
-                else:
-                    raise TypeError(
-                        "Input must either be a tuple containing the dataset name and a clim tuple, or just the clim tuple."
-                    )
-            else:
-                raise ValueError("Input must be a tuple of length 2.")
-        else:
-            raise TypeError("Input must be a tuple.")
-
-        if (not isinstance(clim, tuple)) or (len(clim) != 2):
-            raise ValueError("cmap range should be a tuple of length 2.")
-
-        self._clim[name] = clim
-
-        actors = []
-        actor = self.actors.get(name, None)
-        if actor is not None:
-            actors.append(actor)
-            if (self.filter_actor is not None) and (
-                self.filter_actor_name == name + " filter"
-            ):
-                actors.append(self.filter_actor)
-
-            for actor in actors:
-                actor.mapper.lookup_table.scalar_range = clim
-                actor.mapper.SetUseLookupTableScalarRange(True)
-
-        self.render()
-
-    def reset_clim(self, name, var_name):
-        mesh = self._meshes[name]
-        if name in self.interval_actor_names:
-            try:
-                array = mesh.cell_data[var_name]
-            except:
-                raise KeyError(
-                    f"Variable {var_name} not present in dataset with name {name}."
-                )
-
-        elif name in self.point_actor_names:
-            try:
-                array = mesh.point_data[var_name]
-            except:
-                raise KeyError(
-                    f"Variable {var_name} not present in dataset with name {name}."
-                )
-
-        else:
-            raise ValueError(f"Dataset with name {name} not present.")
-
-        min, max = np.nanmin(array), np.nanmax(array)
-        self.clim = (name, (min, max))
-
-    @property
-    def visibility(self):
-        return self._visibility
-
-    @visibility.setter
-    def visibility(self, key_value_pair):
-        if isinstance(key_value_pair, tuple):
-            if len(key_value_pair) == 2:
-                name, visible = key_value_pair
-            else:
-                raise ValueError(
-                    "Input must be a tuple of length 2, where the first element is the name of the dataset and the second element is the visibility."
-                )
-        elif isinstance(key_value_pair, bool):
-            if len(self.mesh_names) == 1:
-                visible = key_value_pair
-                name = self.mesh_names[0]
-            else:
-                raise ValueError(
-                    "Multiple datasets are present. Please specify name of dataset."
-                )
-        else:
-            raise ValueError("Input must be a tuple or a bool.")
-
-        self._visibility[name] = visible
-
-        actor = self.actors.get(name, None)
-        if actor is not None:
-            if visible == True:
-                self.actors[name].prop.opacity = 1
-            else:
-                self.actors[name].prop.opacity = 0
-
-        self.render()
-
-    @property
-    def opacity(self):
-        return self._opacity
-
-    @opacity.setter
-    def opacity(self, key_value_pair):
-        if isinstance(key_value_pair, tuple):
-            if len(key_value_pair) == 2:
-                name, opacity = key_value_pair
-            else:
-                raise ValueError(
-                    "Input must be a tuple of length 2, where the first element is the name of the dataset and the second element is the opacity."
-                )
-        elif isinstance(key_value_pair, (float, int)):
-            if len(self.mesh_names) == 1:
-                opacity = key_value_pair
-                name = self.mesh_names[0]
-            else:
-                raise ValueError(
-                    "Multiple datasets are present. Please specify name of dataset."
-                )
-        else:
-            raise ValueError("Input must be a tuple, float, or integer.")
-
-        self._opacity[name] = opacity
-        actor = self.actors.get(name, None)
-        if actor is not None:
-            if (self.filter_actor is not None) and (
-                self.filter_actor_name == name + " filter"
-            ):
-                self.filter_actor.prop.opacity = opacity
-                opacity_factor = self.filter_opacity_factor[name]
-            else:
-                opacity_factor = 1
-
-            self.actors[name].prop.opacity = opacity * opacity_factor
-
-            if (self.selection_actor is not None) and (
-                self.selection_actor_name == name + " selection"
-            ):
-                self.selection_actor.prop.opacity = opacity
-
-        self.render()
-
-    @property
-    def selected_data(self):
-        return self._selected_data
-
-    @property
-    def selected_intervals(self):
-        return self._selected_intervals
-
-    @selected_intervals.setter
-    def selected_intervals(self, key_value_pair):
-        if isinstance(key_value_pair, tuple):
-            if len(key_value_pair) == 2:
-                name, intervals = key_value_pair
-                try:
-                    intervals = convert_to_numpy_array(intervals)
-                except:
-                    raise ValueError(
-                        "Intervals must be a sequence, pandas object, or numpy array."
-                    )
-            else:
-                raise ValueError(
-                    "Input must be a tuple of length 2, where the first element is the name of the dataset and the second element is the selected intervals."
-                )
-        else:
-            try:
-                intervals = convert_to_numpy_array(key_value_pair)
-            except:
-                raise ValueError(
-                    "Input must be a tuple, or a sequence, pandas object, or numpy array."
-                )
-
-            if len(self.interval_actor_names) == 1:
-                intervals = key_value_pair
-                name = self.interval_actor_names[0]
-            else:
-                raise ValueError(
-                    "Multiple interval datasets are present. Please specify name of dataset."
-                )
-
-        if name not in self.interval_actor_names:
-            raise ValueError(
-                f"No interval dataset corresponding to {name} is present. Interval dataset name(s) are {self.interval_actor_names}."
-            )
-        if (intervals > self.n_intervals[name]).any() or (intervals < 0).any():
-            raise ValueError(
-                f"Intervals must be between 0 and the number of intervals in the dataset, {self.n_intervals[name] - 1}."
-            )
-        interval_cells = []
-        for interval in intervals:
-            interval_cells += np.arange(
-                interval * self.cells_per_interval[name],
-                (interval + 1) * self.cells_per_interval[name],
-            ).tolist()
-
-        self._selected_intervals = intervals
-        self._selected_cells = interval_cells
-
-        self._update_data_selection_object(name)
-
-    @property
-    def filtered_holes(self):
-        return self._filtered_holes
-
-    # @filtered_holes.setter
-    # def filtered_holes(self, hole_ids):
-
-    @property
-    def data_filter(self):
-        return self._data_filter
-
-    @data_filter.setter
-    def data_filter(self, filter_input):
-        if isinstance(filter_input, tuple):
-            if len(filter_input) == 2:
-                name, filter = filter_input
-            else:
-                raise ValueError(
-                    "Filter must be a tuple of length 2, where the first element is the name of the dataset and the second element is the boolean filter."
-                )
-        else:
-            try:
-                filter = convert_to_numpy_array(filter_input)
-            except:
-                raise ValueError(
-                    "Input must be a tuple, or a sequence, pandas object, or numpy array."
-                )
-
-            data_names = self.interval_actor_names + self.point_actor_names
-            if len(data_names) == 1:
-                filter = filter_input
-                name = data_names[0]
-            else:
-                raise ValueError(
-                    "Multiple datasets are present. Please specify name of dataset to filter."
-                )
-
-        if name in self.interval_actor_names:
-            self.interval_filter = (name, filter)
-        elif name in self.point_actor_names:
-            self.point_filter = (name, filter)
-
-    @property
-    def interval_filter(self):
-        return self._interval_filter
-
-    @interval_filter.setter
-    def interval_filter(self, filter_input):
-        if isinstance(filter_input, tuple):
-            if len(filter_input) == 2:
-                name, filter = filter_input
-            else:
-                raise ValueError(
-                    "Filter must be a tuple of length 2, where the first element is the name of the dataset and the second element is the boolean filter."
-                )
-        else:
-            try:
-                filter = convert_to_numpy_array(filter_input)
-            except:
-                raise ValueError(
-                    "Input must be a tuple, or a sequence, pandas object, or numpy array."
-                )
-            if len(self.interval_actor_names) == 1:
-                filter = filter_input
-                name = self.interval_actor_names[0]
-            else:
-                raise ValueError(
-                    "Multiple interval datasets are present. Please specify name of dataset to filter."
-                )
-
-        if len(filter) != self.n_intervals[name]:  # filter entire dataset
-            raise ValueError(
-                "Filter must be of length equal to number of intervals in dataset."
-            )
-        self._interval_filter = np.array(filter)
-        self._interval_cells_filter = np.repeat(filter, self.cells_per_interval[name])
-
-        self._filtered_intervals = np.arange(self.n_intervals[name])[
-            self.interval_filter
-        ]
-        self._filtered_cells = np.arange(
-            self.n_intervals[name] * self.cells_per_interval[name]
-        )[self._interval_cells_filter]
-
-        self._update_data_filter_object(name)
-
-    @property
-    def point_filter(self):
-        return self._point_filter
-
-    @point_filter.setter
-    def point_filter(self, filter_input):
-        if isinstance(filter_input, tuple):
-            if len(filter_input) == 2:
-                name, filter = filter_input
-            else:
-                raise ValueError(
-                    "Filter must be a tuple of length 2, where the first element is the name of the dataset and the second element is the boolean filter."
-                )
-        else:
-            try:
-                filter = convert_to_numpy_array(filter_input)
-            except:
-                raise ValueError(
-                    "Input must be a tuple, or a sequence, pandas object, or numpy array."
-                )
-            if len(self.point_actor_names) == 1:
-                filter = filter_input
-                name = self.point_actor_names[0]
-            else:
-                raise ValueError(
-                    "Multiple point datasets are present. Please specify name of dataset to filter."
-                )
-
-        if len(filter) != self.n_points[name]:  # filter entire dataset
-            raise ValueError(
-                "Filter must be of length equal to number of points in dataset."
-            )
-
-        self._point_filter = np.array(filter)
-        self._filtered_points = np.arange(self.n_points[name])[self.point_filter]
-
-        self._update_data_filter_object(name)
-
-    def convert_selection_to_filter(self):
-        if self.interval_selection_actor_name is not None:
-            self.convert_interval_selection_to_filter()
-        elif self.point_selection_actor_name is not None:
-            self.convert_point_selection_to_filter()
-
-    def convert_filter_to_selection(self, keep_filter=False):
-        if self.interval_filter_actor_name is not None:
-            self.convert_interval_filter_to_selection(keep_filter)
-        elif self.point_filter_actor_name is not None:
-            self.convert_point_filter_to_selection(keep_filter)
-
-    def convert_interval_selection_to_filter(self):
-        name = self.interval_selection_actor_name.replace(" selection", "")
-        n_intervals = self.n_intervals[name]
-        filter = np.isin(np.arange(n_intervals), self._selected_intervals)
-        self._reset_interval_selection()
-        self.interval_filter = (name, filter)
-
-    def convert_interval_filter_to_selection(self, keep_filter=False):
-        self._selected_cells = self._filtered_cells
-        self._selected_intervals = self._filtered_intervals
-        name = self.interval_filter_actor_name.replace(" filter", "")
-        if keep_filter == False:
-            self._reset_interval_filter()
-        self._update_data_selection_object(name)
-
-    def convert_point_selection_to_filter(self):
-        name = self.point_selection_actor_name.replace(" selection", "")
-        n_points = self.n_points[name]
-        filter = np.isin(np.arange(n_points), self._selected_points)
-        self._reset_point_selection()
-        self.point_filter = (name, filter)
-
-    def convert_point_filter_to_selection(self, keep_filter=False):
-        self._selected_points = self._filtered_points
-        name = self.point_filter_actor_name.replace(" filter", "")
-        if keep_filter == False:
-            self._reset_point_filter()
-        self._update_data_selection_object(name)
-
-    @property
-    def show_collar_labels(self):
-        return self._collar_labels_visible
-
-    @show_collar_labels.setter
-    def show_collar_labels(self, visible):
-        self._collar_labels_visible = visible
-        if visible == True:
-            self.add_actor(
-                self.collar_label_actor, name="collar labels", reset_camera=False
-            )
-        elif visible == False:
-            self.remove_actor(self.collar_label_actor)
-
-    def _process_data_output(self, name, indices, step=1):
-        holes_mesh = self._meshes[name]
-        exclude_vars = [
-            "TubeNormals",
-            "vtkOriginalPointIds",
-            "vtkOriginalCellIds",
-        ]  # added by pyvista
-        vars = [var for var in holes_mesh.array_names if var not in exclude_vars]
-        data_dict = {}
-        for var in vars:
-            data_dict[var] = holes_mesh[var][::step][indices]
-
-        data = pd.DataFrame(data_dict)
-        data["hole ID"] = [
-            self.code_to_hole_id_map[name][code] for code in data["hole ID"]
-        ]
-        for var in self.categorical_vars[name]:
-            data[var] = data[var].astype("category")
-            data[var] = [self.code_to_cat_map[name][var][code] for code in data[var]]
-
-        return data
-
-    def _process_selected_data_output(self, indices, step=1):
-        selection_name = self.selection_actor_name
-        name = selection_name.replace(" selection", "")
-        data = self._process_data_output(name, indices, step)
-
-        return data
-
-    def selected_interval_data(self):
-        intervals = self._selected_intervals
-        selection_name = self.selection_actor_name
-        name = selection_name.replace(" selection", "")
-        data = self._process_selected_data_output(
-            intervals, self.cells_per_interval[name]
-        )
-
-        return data
-
-    def selected_point_data(self):
-        points = self._selected_points
-        data = self._process_selected_data_output(points)
-
-        return data
-
-    def selected_data(self):
-        name = self.selection_actor_name.replace(" selection", "")
-        if name in self.interval_actor_names:
-            return self.selected_interval_data()
-        elif name in self.point_actor_names:
-            return self.selected_point_data()
-
-    def all_interval_data(self, name=None):
-        if name is None:
-            names = self.interval_actor_names
-        else:
-            if name in self.interval_actor_names:
-                names = [name]
-            else:
-                raise ValueError(f"{name} is not a valid dataset name.")
-
-        all_data = {}
-        for name in names:
-            intervals = np.arange(self.n_intervals[name])
-            data = self._process_data_output(
-                name, intervals, self.cells_per_interval[name]
-            )
-            all_data[name] = data
-
-        if len(names) == 1:
-            return all_data[name]
-        else:
-            return all_data
-
-    def all_point_data(self, name=None):
-        if name is None:
-            names = self.point_actor_names
-        else:
-            if name in self.point_actor_names:
-                names = [name]
-            else:
-                raise ValueError(f"{name} is not a valid dataset name.")
-
-        all_data = {}
-        for name in names:
-            points = np.arange(self.n_points[name])
-            data = self._process_data_output(name, points)
-            all_data[name] = data
-
-        if len(names) == 1:
-            return all_data[name]
-        else:
-            return all_data
-
-    def all_data(self, name=None):
-        if name is not None:
-            if name in self.interval_actor_names:
-                return self.all_interval_data(name)
-            elif name in self.point_actor_names:
-                return self.all_point_data(name)
-            else:
-                raise ValueError(f"{name} is not a valid dataset name.")
-        else:
-            all_point_data = self.all_point_data()
-            all_interval_data = self.all_interval_data()
-
-            return all_point_data, all_interval_data
-
-    @property
-    def selected_hole_ids(self):
-        return self._selected_hole_ids
-
-    @selected_hole_ids.setter
-    def selected_hole_ids(self, hole_ids):
-        if isinstance(hole_ids, str):
-            hole_ids = [hole_ids]
-        self._selected_hole_ids = hole_ids
-
-        # filter interval data
-        for name in self.interval_actor_names:
-            interval_data = self.all_interval_data(name)
-            interval_filter = interval_data["hole ID"].isin(hole_ids)
-            self.interval_filter = (name, interval_filter)
-
-        # filter point data
-        for name in self.point_actor_names:
-            point_data = self.all_point_data(name)
-            point_filter = point_data["hole ID"].isin(hole_ids)
-            self.point_filter = (name, point_filter)
-
-    def selected_drill_log(
-        self,
-        log_vars=[],
-    ):
-        interval_data = self.selected_interval_data()
-        # point_data = self.selected_point_data()
-
-        hole_id = interval_data["hole ID"].unique()
-        if len(hole_id) == 1:
-            # check if no variables are passed; if so, use all variables
-            if len(log_vars) == 0:
-                interval_vars = (
-                    self.categorical_interval_vars + self.continuous_interval_vars
-                )
-                point_vars = self.categorical_point_vars + self.continuous_point_vars
-                log_vars = interval_vars + point_vars
-
-            log = DrillLog()
-
-            # add interval data
-            depths = interval_data[["from", "to"]].values
-
-            for var in log_vars:
-                for name in self.interval_actor_names:
-                    if var in self.categorical_vars[name]:
-                        cat_to_color_map = self.cat_to_color_map[name]
-                        values = interval_data[var].values
-                        log.add_categorical_interval_data(
-                            var,
-                            depths,
-                            values,
-                            cat_to_color_map.get(var, None),
-                        )
-
-                        exit_flag = True
-                        break
-
-                    elif var in self.continuous_vars[name]:
-                        values = interval_data[var].values
-                        log.add_continuous_interval_data(var, depths, values)
-
-                        exit_flag = True
-                        break
-                    else:
-                        raise ValueError(f"Data for variable {var} not present.")
-
-                    if exit_flag == True:
-                        break
-
-                # for name in self.point_actor_names:
-                #     if var in self.categorical_vars[name]:
-                #         cat_to_color_map = self.cat_to_color_map[name]
-                #         values = point_data[var].values
-                #         log.add_categorical_point_data(
-                #             var, depths, values, cat_to_color_map.get(var, None)
-                #         )
-                #         exit_flag = True
-                #         break
-
-                #     if var in self.continuous_vars[name]:
-                #         values = point_data[var].values
-                #         log.add_continuous_point_data(var, depths, values)
-                #         exit_flag = True
-                #         break
-
-                #     if exit_flag == True:
-                #         break
-
-            log.create_figure(y_axis_label="Depth (m)", title=hole_id[0])
-
-            return log.fig
+        for layer in self.layers:
+            layer._reset_selection()
+            layer._reset_filter()
 
     def iframe(self, w="100%", h=None):
         if h is None:

--- a/drilldown/plotter.py
+++ b/drilldown/plotter.py
@@ -68,6 +68,8 @@ class DrillDownPlotter(Plotter):
             side="left", callback=self._on_double_click, double=True
         )
 
+        # track active selections and filters across layers
+        self._active_selections_and_filters = []
         # spin up a server to manager GUI, if present
         self.server = get_server(str(uuid.uuid4()))
         self.state = self.server.state
@@ -282,8 +284,14 @@ class DrillDownPlotter(Plotter):
         if picked_actor is not None:
             self._pick_on_dbl_click(picked_actor)
 
-        else:
-            self._reset_data()
+        elif len(self._active_selections_and_filters) > 0:
+            selection_or_filter = self._active_selections_and_filters[-1]
+            layer_name = list(selection_or_filter.keys())[0]
+            layer = self.layers[layer_name]
+            if selection_or_filter[layer_name] == "selection":
+                layer._reset_selection()
+            elif selection_or_filter[layer_name] == "filter":
+                layer._reset_filter()
 
     def _pick(self):
         pos = self.click_position

--- a/drilldown/plotter.py
+++ b/drilldown/plotter.py
@@ -33,6 +33,7 @@ from .drill_log import DrillLog
 from .utils import convert_to_numpy_array
 from .image.image_mixin import ImageMixin
 from .plot.plotting_mixin import Plotting2dMixin
+from .layer.layer import DataLayer
 
 
 def is_numeric_tuple(tup):
@@ -61,6 +62,7 @@ class DrillDownPlotter(Plotter, Plotting2dMixin, ImageMixin):
         self.enable_trackball_style()
         vtkMapper.SetResolveCoincidentTopologyToPolygonOffset()
 
+        self.layers = {}
         self.collars = None
         self.surveys = None
         self.datasets = {}
@@ -315,6 +317,19 @@ class DrillDownPlotter(Plotter, Plotting2dMixin, ImageMixin):
             *args,
             **kwargs,
         )
+
+        self.layers[name] = DataLayer(
+            name,
+            mesh,
+            actor,
+            self,
+            opacity=opacity,
+            pickable=selectable,
+            active_var=active_var,
+            cmap=cmap,
+            clim=clim,
+        )
+
         if active_var is None:  # default to first variable
             self.active_var = (name, self.all_vars[name][0])
         else:

--- a/drilldown/plotter.py
+++ b/drilldown/plotter.py
@@ -5,13 +5,16 @@ from vtk import (
 )
 from pyvista import Plotter
 from pyvista.trame.jupyter import show_trame
+from trame.app import get_server
 
 from IPython.display import IFrame
+import uuid
 
 from .image.image_mixin import ImageMixin
 from .plot.plotting_mixin import Plotting2dMixin
 from .layer.layer import IntervalDataLayer, PointDataLayer
 from .layer.layer_list import LayerList
+from .utils import is_jupyter
 
 
 def is_numeric_tuple(tup):
@@ -61,6 +64,12 @@ class DrillDownPlotter(Plotter, Plotting2dMixin, ImageMixin):
         # track clicks
         self.track_click_position(side="left", callback=self._pick)
         self.track_click_position(side="left", callback=self._reset_data, double=True)
+
+        # spin up a server to manager GUI, if present
+        self.server = get_server(str(uuid.uuid4()))
+        self.state = self.server.state
+        self.server.client_type = "vue2"
+        self.state.layer_names = []
 
     def add_collars(self, collars, show_labels=True, opacity=1, *args, **kwargs):
         from .holes import Collars
@@ -121,7 +130,7 @@ class DrillDownPlotter(Plotter, Plotting2dMixin, ImageMixin):
         selectable=True,
         radius=1.5,
         n_sides=20,
-        active_var=None,
+        active_array_name=None,
         cmap=None,
         clim=None,
         selection_color="magenta",
@@ -146,7 +155,7 @@ class DrillDownPlotter(Plotter, Plotting2dMixin, ImageMixin):
             name=name,
             opacity=opacity,
             pickable=selectable,
-            scalars=active_var,
+            scalars=active_array_name,
             cmap=cmap,
             clim=clim,
             show_scalar_bar=False,
@@ -182,7 +191,7 @@ class DrillDownPlotter(Plotter, Plotting2dMixin, ImageMixin):
         opacity=1,
         point_size=10,
         selectable=True,
-        active_var=None,
+        active_array_name=None,
         cmap=None,
         clim=None,
         selection_color="magenta",
@@ -207,7 +216,7 @@ class DrillDownPlotter(Plotter, Plotting2dMixin, ImageMixin):
             pickable=selectable,
             point_size=point_size,
             render_points_as_spheres=True,
-            scalars=active_var,
+            scalars=active_array_name,
             show_scalar_bar=False,
             cmap=cmap,
             clim=clim,

--- a/drilldown/plotter.py
+++ b/drilldown/plotter.py
@@ -139,6 +139,7 @@ class DrillDownPlotter(Plotter):
         selection_color="magenta",
         filter_opacity=0.1,
         accelerated_selection=False,
+        visibility=True,
         *args,
         **kwargs,
     ):
@@ -153,6 +154,7 @@ class DrillDownPlotter(Plotter):
         mesh = intervals.mesh
         mesh = mesh.tube(radius=radius, n_sides=n_sides, capping=False)
 
+        kwargs = {k: v for k, v in kwargs.items() if k != "visibility"}
         actor = self.add_mesh(
             mesh,
             name=name,
@@ -166,7 +168,18 @@ class DrillDownPlotter(Plotter):
             **kwargs,
         )
 
-        layer = IntervalDataLayer(name, mesh, actor, self, n_sides=n_sides)
+        actor.visibility = visibility
+
+        layer = IntervalDataLayer(
+            name,
+            mesh,
+            actor,
+            self,
+            visibility=visibility,
+            opacity=opacity,
+            n_sides=n_sides,
+            selection_color=selection_color,
+        )
 
         # handle categorical, continuous, and image arrays
         layer._categorical_array_names = intervals.categorical_vars
@@ -192,14 +205,15 @@ class DrillDownPlotter(Plotter):
         points,
         name,
         opacity=1,
-        point_size=10,
         selectable=True,
+        point_size=10,
         active_array_name=None,
         cmap=None,
         clim=None,
         selection_color="magenta",
         filter_opacity=0.1,
         accelerated_selection=False,
+        visibility=True,
         *args,
         **kwargs,
     ):
@@ -212,6 +226,8 @@ class DrillDownPlotter(Plotter):
             points.make_mesh()
 
         mesh = points.mesh
+
+        kwargs = {k: v for k, v in kwargs.items() if k != "visibility"}
         actor = self.add_mesh(
             mesh,
             name=name,
@@ -227,7 +243,17 @@ class DrillDownPlotter(Plotter):
             **kwargs,
         )
 
-        layer = PointDataLayer(name, mesh, actor, self)
+        actor.visibility = visibility
+
+        layer = PointDataLayer(
+            name,
+            mesh,
+            actor,
+            self,
+            visibility=visibility,
+            opacity=opacity,
+            selection_color=selection_color,
+        )
 
         # handle categorical, continuous, and image arrays
         layer._categorical_array_names = points.categorical_vars

--- a/drilldown/plotter.py
+++ b/drilldown/plotter.py
@@ -265,7 +265,9 @@ class DrillDownPlotter(Plotter):
 
             # make selection
             for layer in self.layers:
-                if layer.actor == picked_actor:
+                if (layer.actor == picked_actor) or (
+                    layer.filter_actor == picked_actor
+                ):
                     layer._make_selection_by_pick(pos, picked_actor)
                     layer._update_selection_object()
 

--- a/drilldown/plotter.py
+++ b/drilldown/plotter.py
@@ -10,7 +10,6 @@ from trame.app import get_server
 from IPython.display import IFrame
 import uuid
 
-from .image.image_mixin import ImageMixin
 from .plot.plotting_mixin import Plotting2dMixin
 from .layer.layer import IntervalDataLayer, PointDataLayer
 from .layer.layer_list import LayerList
@@ -30,7 +29,7 @@ def actors_collection_to_list(actors_collection):
     return actors_list
 
 
-class DrillDownPlotter(Plotter, Plotting2dMixin, ImageMixin):
+class DrillDownPlotter(Plotter, Plotting2dMixin):
     """Plotting object for displaying drillholes and related datasets."""
 
     def __init__(self, *args, **kwargs):
@@ -165,9 +164,10 @@ class DrillDownPlotter(Plotter, Plotting2dMixin, ImageMixin):
 
         layer = IntervalDataLayer(name, mesh, actor, self, n_sides=n_sides)
 
-        # handle categorical vs continuous arrays
+        # handle categorical, continuous, and image arrays
         layer._categorical_array_names = intervals.categorical_vars
         layer._continuous_array_names = intervals.continuous_vars
+        layer._image_array_names = intervals.image_var_names
 
         # enable decoding of hole IDs and categorical arrays
         layer.code_to_hole_id_map = intervals.code_to_hole_id_map
@@ -226,9 +226,10 @@ class DrillDownPlotter(Plotter, Plotting2dMixin, ImageMixin):
 
         layer = PointDataLayer(name, mesh, actor, self)
 
-        # handle categorical vs continuous arrays
+        # handle categorical, continuous, and image arrays
         layer._categorical_array_names = points.categorical_vars
         layer._continuous_array_names = points.continuous_vars
+        layer._image_array_names = points.image_var_names
 
         # enable decoding of hole IDs and categorical arrays
         layer.code_to_hole_id_map = points.code_to_hole_id_map

--- a/drilldown/plotter.py
+++ b/drilldown/plotter.py
@@ -10,7 +10,6 @@ from trame.app import get_server
 from IPython.display import IFrame
 import uuid
 
-from .plot.plotting_mixin import Plotting2dMixin
 from .layer.layer import IntervalDataLayer, PointDataLayer
 from .layer.layer_list import LayerList
 from .utils import is_jupyter
@@ -29,7 +28,7 @@ def actors_collection_to_list(actors_collection):
     return actors_list
 
 
-class DrillDownPlotter(Plotter, Plotting2dMixin):
+class DrillDownPlotter(Plotter):
     """Plotting object for displaying drillholes and related datasets."""
 
     def __init__(self, *args, **kwargs):

--- a/drilldown/plotter.py
+++ b/drilldown/plotter.py
@@ -287,7 +287,6 @@ class DrillDownPlotter(Plotter):
         for layer in self.layers:
             if (layer.actor == picked_actor) or (layer.filter_actor == picked_actor):
                 layer._make_selection_by_pick(pos, picked_actor)
-                layer._update_selection_object()
                 self.picked_layer = layer
 
         # restore previous pickable state

--- a/drilldown/ui/ui.py
+++ b/drilldown/ui/ui.py
@@ -163,7 +163,7 @@ class DrillDownTramePlotter(DrillDownPlotter):
             # update cmap
             if state.active_var in layer.continuous_array_names:
                 state.cmap_visible = True
-                state.cmap_fields = layer.cmaps
+                state.cmap_fields = layer._cmaps
                 state.cmap = layer.cmap
 
                 state.clim_visible = True

--- a/drilldown/ui/ui.py
+++ b/drilldown/ui/ui.py
@@ -11,21 +11,7 @@ import panel as pn
 from functools import partial
 
 from ..plotter import DrillDownPlotter
-
-
-def is_jupyter():
-    from IPython import get_ipython
-
-    try:
-        shell = get_ipython().__class__.__name__
-        if shell == "ZMQInteractiveShell":
-            return True  # Jupyter notebook or qtconsole
-        elif shell == "TerminalInteractiveShell":
-            return False  # Terminal running IPython
-        else:
-            return False  # Other type (?)
-    except NameError:
-        return False
+from ..utils import is_jupyter
 
 
 def ui_card(title, ui_name):

--- a/drilldown/utils.py
+++ b/drilldown/utils.py
@@ -51,27 +51,14 @@ def encode_categorical_data(data):
     codes = np.array(codes, dtype="float")
     data_encoded = np.array(data_encoded, dtype="float")
 
-    # center numerical representation of categorical data, while maintaining range, to address pyvista's color mapping querks
-    codes[1:-1] += 0.5
-    data_encoded[
-        (data_encoded != data_encoded.min()) & (data_encoded != data_encoded.max())
-    ] += 0.5
+    # # center numerical representation of categorical data, while maintaining range, to address pyvista's color mapping querks
+    # codes[1:-1] += 0.5
+    # data_encoded[
+    #     (data_encoded != data_encoded.min()) & (data_encoded != data_encoded.max())
+    # ] += 0.5
     code_to_cat_map = {code: cat for code, cat in zip(codes, categories)}
 
     return code_to_cat_map, data_encoded
-
-
-def make_matplotlib_categorical_color_map(colors):
-    mapping = np.linspace(0, len(colors) - 1, 256)
-    new_colors = np.empty((256, 3))
-    i_pre = -np.inf
-    for i, color in enumerate(colors):
-        new_colors[(mapping > i_pre) & (mapping <= i)] = list(color)
-        i_pre = i
-    map = ListedColormap(colors[0:-1])
-    map.set_under(colors[0])
-    map.set_over(colors[-1])
-    return map
 
 
 def get_cycled_colors(n):
@@ -113,8 +100,9 @@ def make_categorical_cmap(categories, cycle=True, rng=999, pastel_factor=0.2):
 
     # create categorical color map
     cat_to_color_map = {cat: color for cat, color in zip(categories, colors)}
+
     # create matplotlib categorical color map
-    matplotlib_formatted_color_maps = make_matplotlib_categorical_color_map(colors)
+    matplotlib_formatted_color_maps = ListedColormap(colors)
 
     return cat_to_color_map, matplotlib_formatted_color_maps
 

--- a/drilldown/utils.py
+++ b/drilldown/utils.py
@@ -23,3 +23,18 @@ def convert_to_numpy_array(arr, collapse_dim=True):
         raise TypeError("Data must be a sequence or Pandas object.")
 
     return arr
+
+
+def is_jupyter():
+    from IPython import get_ipython
+
+    try:
+        shell = get_ipython().__class__.__name__
+        if shell == "ZMQInteractiveShell":
+            return True  # Jupyter notebook or qtconsole
+        elif shell == "TerminalInteractiveShell":
+            return False  # Terminal running IPython
+        else:
+            return False  # Other type (?)
+    except NameError:
+        return False

--- a/drilldown/utils.py
+++ b/drilldown/utils.py
@@ -120,3 +120,10 @@ def is_jupyter():
             return False  # Other type (?)
     except NameError:
         return False
+
+
+def round_to_sig_figs(num, sig_figs):
+    if num != 0:
+        return round(num, -int(np.floor(np.log10(abs(num))) - (sig_figs - 1)))
+    else:
+        return 0  # Can't take the log of 0

--- a/drilldown/utils.py
+++ b/drilldown/utils.py
@@ -1,6 +1,8 @@
 import collections.abc
 import numpy as np
 import pandas as pd
+import distinctipy
+from matplotlib.colors import ListedColormap
 
 
 def convert_to_numpy_array(arr, collapse_dim=True):
@@ -23,6 +25,98 @@ def convert_to_numpy_array(arr, collapse_dim=True):
         raise TypeError("Data must be a sequence or Pandas object.")
 
     return arr
+
+
+def convert_array_type(arr, return_type=False):
+    try:
+        arr = arr.astype("float")
+        _type = "float"
+    except ValueError:
+        arr = arr.astype("str")
+        _type = "str"
+
+    if return_type == True:
+        return arr, _type
+    else:
+        return arr
+
+
+def encode_categorical_data(data):
+    data = convert_to_numpy_array(data)
+
+    data_encoded, categories = pd.factorize(data)
+    codes = np.arange(len(categories))
+
+    # convert codes to float
+    codes = np.array(codes, dtype="float")
+    data_encoded = np.array(data_encoded, dtype="float")
+
+    # center numerical representation of categorical data, while maintaining range, to address pyvista's color mapping querks
+    codes[1:-1] += 0.5
+    data_encoded[
+        (data_encoded != data_encoded.min()) & (data_encoded != data_encoded.max())
+    ] += 0.5
+    code_to_cat_map = {code: cat for code, cat in zip(codes, categories)}
+
+    return code_to_cat_map, data_encoded
+
+
+def make_matplotlib_categorical_color_map(colors):
+    mapping = np.linspace(0, len(colors) - 1, 256)
+    new_colors = np.empty((256, 3))
+    i_pre = -np.inf
+    for i, color in enumerate(colors):
+        new_colors[(mapping > i_pre) & (mapping <= i)] = list(color)
+        i_pre = i
+    map = ListedColormap(colors[0:-1])
+    map.set_under(colors[0])
+    map.set_over(colors[-1])
+    return map
+
+
+def get_cycled_colors(n):
+    from itertools import cycle
+    import matplotlib as mpl
+
+    cycler = mpl.rcParams["axes.prop_cycle"]
+    colors = cycle(cycler)
+    colors = [next(colors)["color"] for i in range(n)]
+    colors = [mpl.colors.to_rgb(color) for color in colors]
+
+    return colors
+
+
+def make_color_map_fractional(map):
+    for name in map.keys():
+        if max(map[name]) > 1:
+            map[name] = tuple([val / 255 for val in map[name]])
+        elif max(map[name]) >= 0:
+            # raise ValueError("Color is already fractional.")
+            pass
+        else:
+            raise ValueError("Color values cannot be negative.")
+
+    return map
+
+
+def make_categorical_cmap(categories, cycle=True, rng=999, pastel_factor=0.2):
+    n_colors = len(categories)
+    if cycle == True:
+        colors = get_cycled_colors(n_colors)
+
+    elif cycle == False:
+        colors = distinctipy.get_colors(
+            n_colors,
+            pastel_factor=pastel_factor,
+            rng=rng,
+        )
+
+    # create categorical color map
+    cat_to_color_map = {cat: color for cat, color in zip(categories, colors)}
+    # create matplotlib categorical color map
+    matplotlib_formatted_color_maps = make_matplotlib_categorical_color_map(colors)
+
+    return cat_to_color_map, matplotlib_formatted_color_maps
 
 
 def is_jupyter():


### PR DESCRIPTION
Layers are analogous to those found in GIS and image analysis software (e.g., Napari), where they are viewable objects representing different data types and ways of visualizing. In DrillDown, however, datasets exist along 3D drillholes (parameterized as 1D paths) rather than typically 2D planes. Thus layers correspond to drillhole datasets collected along such 1D paths. For example, assay intervals would be represented using the `IntervalDataLayer` class, and point samples with the `PointDataLayer` class. Multiple layers — of different or the same type —can be present on a given plotter. For example, a plotter might have four layers, corresponding to assay intervals, lithology intervals, core photo intervals, and sample points. While the the first three all represent interval data, their sampling density and associated boundaries vary, and so they are represented as three different layers. Nevertheless, layers can filter and select on one another, providing convenient ways to have disparate datasets interact with one another. 
Additionally, each dataset (and mesh) corresponding to a layer is associated with multiple actors (i.e., the main dataset actor, a selection actor, and a filter actor). Layers extend PyVista's mesh-actor framework to provide a convenient way to store information about these actors in one place and control their properties together. Finally, the move towards layers lays the groundwork for working with increasingly variable and multi-dimensional datasets collected along drillholes, which now may include hyperspectral, XRF, and/or LIBS core-scanning datasets in addition to traditional logging and assay datasets.