### PR TITLE
Properly initialize ui without cmap_fields

### DIFF
--- a/drilldown/ui/ui.py
+++ b/drilldown/ui/ui.py
@@ -118,6 +118,8 @@ class DrillDownPlotter(Plotter):
 
             else:
                 state.cmap_visible = False
+                state.cmap_fields = []
+
                 state.clim_visible = False
 
             state.visibility = layer.visibility


### PR DESCRIPTION
if UI initialized when categorical data array is active, set `cmap_fields` to empty list