### PR TITLE
Resolve multi-server trame issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ plotly==5.18.0
 pyvista==0.43.0
 trame==3.4.0
 trame-markdown==3.0.1
-trame-vtk==2.6.2
+trame-vtk==2.7.0
 trame-vuetify==2.3.1
 trame-plotly==3.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ distinctipy==1.2.3
 geoh5py==0.8.0rc3
 ipykernel==6.27.1
 jupyter==1.0.0
-panel==1.3.4
 plotly==5.18.0
 pyvista==0.43.0
 trame==3.4.0


### PR DESCRIPTION
- Also remove panel dependency (hasn't been needed in a while)
- Two trame apps can now be launched from a jupyter notebook (e.g., a plotter and a scatter plot, which are both trame micro apps) as of  trame-vtk=2.7.0, if the name passed to `get_server` for each is different, and the `template_name` for `SinglePageLayout` for each is different)
- resolves #21